### PR TITLE
Move the build inside a container

### DIFF
--- a/management/README.md
+++ b/management/README.md
@@ -3,10 +3,16 @@
 ### 1. checkout and build the code
 ```
 cd $GOPATH/src/github.com/contiv/
-git clone https://github.com/mapuri/cluster.git
+git clone https://github.com/contiv/cluster.git
 cd cluster/management/src
-git checkout collins
 make build
+```
+
+**Note**: `build` is run inside a docker container, so it requires docker to be installed
+and running on the host. To avoid having to use `sudo` for builds you can add the current
+user to `docker` group once by using the following command:
+```
+sudo adduser `id -un` docker
 ```
 
 ### 2. launch three vagrant nodes. 

--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -1,5 +1,8 @@
-.PHONY: checks check-format check-code deps generate unit-test test-app
+.PHONY: checks check-format check-code clean deps generate unit-test
 
+work_dir:=/go/src/github.com/contiv/cluster/management/src
+docker_run:=docker run --rm -u `id -u`:`id -g` -v `pwd`:$(work_dir) \
+	-v $(GOPATH)/bin:/go/bin -w $(work_dir) golang:1.4
 all: build unit-test
 
 deps:
@@ -40,13 +43,13 @@ check-code:
 
 build: checks generate
 	@echo "building..."
-	@godep go install ./...
+	@$(docker_run) godep go install ./...
 	@make clean-generate
 	@echo "done building..."
 
 unit-test: checks generate
 	@echo "running unit-tests"
-	@godep go list ./... | xargs -n1 go test
+	@$(docker_run) sh -c "godep go list ./... | xargs -n1 godep go test"
 	@make clean-generate
 	@echo "done running unit-tests"
 


### PR DESCRIPTION
cluster builds require Go1.4 or less due to a dependency on serf, hence moving to a build inside the container inorder to have control over the go version.

Also made some minor fixes to docs.
