### PR TITLE
Makefile: add a `demo`, `start`, and `stop` targets that use a standard configuration specifically for demo purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+demo: stop start
+stop:
+	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_SRV_INIT=1 vagrant destroy -f
+start:
+	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_SRV_INIT=1 vagrant up


### PR DESCRIPTION
This allows us to quickly bootstrap an integrated environment -- without having to remember or type large command lines.

Hopefully this is a useful change to add to the build system

Signed-off-by: Erik Hollensbe github@hollensbe.org
