### PR TITLE
make error channels buffered to avoid goroutine from blocking

### DIFF
--- a/management/src/clusterm/main.go
+++ b/management/src/clusterm/main.go
@@ -100,6 +100,7 @@ func startDaemon(c *cli.Context) {
 	// set log level
 	level := c.GlobalGeneric("debug").(*logLevel)
 	log.SetLevel(level.value)
+	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
 
 	var (
 		err    error
@@ -114,7 +115,7 @@ func startDaemon(c *cli.Context) {
 	}
 
 	// start manager's processing loop
-	errCh := make(chan error)
+	errCh := make(chan error, 5)
 	go mgr.Run(errCh)
 	select {
 	case err := <-errCh:

--- a/management/src/configuration/ansible.go
+++ b/management/src/configuration/ansible.go
@@ -77,7 +77,8 @@ func (a *AnsibleSubsys) ansibleRunner(nodes []*AnsibleHost, playbook, extraVars 
 	}
 	runner := ansible.NewRunner(ansible.NewInventory(iNodes), playbook, a.config.User, a.config.PrivKeyFile, vars)
 	r, w := io.Pipe()
-	errCh := make(chan error)
+	// make error channel buffered, so it doesn't block
+	errCh := make(chan error, 1)
 	go func(outStream io.Writer, errCh chan error) {
 		defer r.Close()
 		if err := runner.Run(outStream, outStream); err != nil {


### PR DESCRIPTION
**Problem description**
The err channel in ansible runner (`ansibleRunner()`) is used to asynchronously pass the log-stream (io.pipe) and exit code of ansible run back to the event processor. The exit code is sent on a channel. The event processor prints the logs while waiting for exit code to arrive on the channel.

With unbuffered channel a deadlock happens sometime if the ansible commands fails early on and log stream reader in event processor blocks waiting on that stream to close (which happens when ansible runner exits) while ansible runner blocks on error channel (waiting for event processor to dequeue the error).

**Solution:**
Making the error channel buffered prevents  the deadlock condition, as writing to error channel doesn't block any more which lets the ansible runner keep making progress and gracefully close the log stream and exit.
