### PR TITLE
align cluster-manager to recent ansible changes

### DIFF
--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -26,9 +26,10 @@ const (
 )
 
 const (
-	ansibleMasterGroupName         = "service-master"
-	ansibleWorkerGroupName         = "service-worker"
-	ansibleNodeNameHostVar         = "node_name"
-	ansibleNodeAddrHostVar         = "node_addr"
-	ansibleOnlineMasterAddrHostVar = "online_master_addr"
+	ansibleMasterGroupName       = "service-master"
+	ansibleWorkerGroupName       = "service-worker"
+	ansibleNodeNameHostVar       = "node_name"
+	ansibleNodeAddrHostVar       = "node_addr"
+	ansibleEtcdMasterAddrHostVar = "etcd_master_addr"
+	ansibleEtcdMasterNameHostVar = "etcd_master_name"
 )

--- a/management/src/configuration/ansible.go
+++ b/management/src/configuration/ansible.go
@@ -42,6 +42,16 @@ func NewAnsibleHost(tag, addr, group string, vars map[string]string) *AnsibleHos
 	}
 }
 
+// GetTag return the ansible inventory name/tag for the host
+func (h *AnsibleHost) GetTag() string {
+	return h.tag
+}
+
+// GetGroup return the ansible inventory group/role for the host
+func (h *AnsibleHost) GetGroup() string {
+	return h.group
+}
+
 // SetVar sets a host variable value
 func (h *AnsibleHost) SetVar(key, val string) {
 	h.vars[key] = val

--- a/management/src/configuration/configuration.go
+++ b/management/src/configuration/configuration.go
@@ -14,7 +14,12 @@ type Subsys interface {
 }
 
 // SubsysHost denotes a host in configuration subsystem
-type SubsysHost interface{}
+type SubsysHost interface {
+	// GetTag returns the name/tag associated with the host in configuration sub-system
+	GetTag() string
+	//GetGroup returns the group/role associated with the host in configuration sub-system
+	GetGroup() string
+}
 
 // SubsysHosts denotes a collection of hosts in configuration subsystem
 type SubsysHosts interface{}


### PR DESCRIPTION
- replaced online-master-addr with etcd specific variables
- fixed role assignment logic to skip worker nodes while trying to determin etcd master details
