### PR TITLE
Remove gopath related dependencies from build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+management/src/bin/*
 
 # Folders
 _obj

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,8 +60,8 @@ chown -R vagrant:vagrant #{gopath_dir}
 if [ "#{service_init}" = "false" ]; then
     echo mounting binaries from dev workspace
     rm -f /usr/bin/clusterm /usr/bin/clusterctl
-    ln -s #{gobin_dir}/clusterm /usr/bin/clusterm
-    ln -s #{gobin_dir}/clusterctl /usr/bin/clusterctl
+    ln -s #{gopath_dir}/src/github.com/contiv/clustermanagement/src/bin/clusterm /usr/bin/clusterm
+    ln -s #{gopath_dir}/src/github.com/contiv/clustermanagement/src/bin/clusterctl /usr/bin/clusterctl
 else
     echo using released binaries
 fi
@@ -124,9 +124,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 #mount the repo directory to a fixed directory, that get's referred
                 #in a test specific conf file (see the test-suite setup function)
                 node.vm.synced_folder ".", "/vagrant"
-
-                # mount the host's gobin path for cluster related binaries to be available
-                node.vm.synced_folder "#{ENV['GOPATH']}/bin", gobin_dir
 
                 # expose collins port to host for ease of management
                 node.vm.network "forwarded_port", guest: 9000, host: 9000

--- a/management/README.md
+++ b/management/README.md
@@ -1,5 +1,10 @@
 ## 3 steps to Contiv Cluster Management
 
+### 0. Ensure correct dependencies are installed
+- docker 1.9 or higher
+- vagrant 1.7.3 or higher
+- virtualbox 5.0 or higher
+
 ### 1. checkout and build the code
 ```
 cd $GOPATH/src/github.com/contiv/

--- a/management/src/Dockerfile
+++ b/management/src/Dockerfile
@@ -1,0 +1,24 @@
+# This file describes the environment setup to build cluster-manager
+FROM golang:1.5
+
+ENV GOPATH=/go
+
+ARG user
+ARG uid
+# give permissions on gopath dir to the build user and then set it as current user
+RUN useradd --uid ${uid} --password foo ${user}
+RUN chown -R ${uid}:${uid} ${GOPATH}
+USER ${user}
+
+# Pre-install dependencies
+RUN go get github.com/tools/godep
+RUN go get github.com/golang/lint/golint
+RUN go get golang.org/x/tools/cmd/stringer
+RUN go get github.com/golang/mock/gomock
+RUN go get github.com/golang/mock/mockgen
+
+# set GOBIN to make go install cluster binaries there
+ARG work_dir
+ENV GOBIN=${work_dir}/bin
+
+CMD bash

--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -1,8 +1,17 @@
-.PHONY: build checks check-format check-code clean clean-generate clean-tar deps generate unit-test system-test tar release
+.PHONY: build build-docker-img build-docker-shell checks check-format check-code clean-generate clean-tar deps generate host-system-test unit-test system-test tar release
 
 work_dir:=/go/src/github.com/contiv/cluster/management/src
-docker_run:=docker run --rm -u `id -u`:`id -g` -v `pwd`:$(work_dir) \
-	-v $(GOPATH)/bin:/go/bin -w $(work_dir) golang:1.5
+docker_buildargs := \
+	--build-arg "uid=$$(id -u)" \
+	--build-arg "user=$$(id -un)" \
+	--build-arg "work_dir=$(work_dir)" \
+	$(if $(HTTP_PROXY), --build-arg "HTTP_PROXY=$(HTTP_PROXY)") \
+	$(if $(HTTPS_PROXY), --build-arg "HTTPS_PROXY=$(HTTPS_PROXY)") \
+	$(if $(http_proxy), --build-arg "http_proxy=$(http_proxy)") \
+	$(if $(https_proxy), --build-arg "https_proxy=$(https_proxy)")
+docker_img := cluster-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
+docker_run:=docker run --rm -u `id -un`:`id -un` -v `pwd`:$(work_dir) \
+	-w $(work_dir) "$(docker_img)"
 unittest_tag:=unittest
 systemtest_tag:=systemtest
 all_tags:=$(unittest_tag) $(systemtest_tag)
@@ -43,16 +52,24 @@ check-code:
 	@godep go vet -tags "$(all_tags)" ./...
 	@echo "done checking code..."
 
-build: checks generate
+build-docker-img:
+	docker build -t "$(docker_img)" $(docker_buildargs) .
+
+build-docker-shell:
+	@$(docker_run) bash
+
+build: build-docker-img
 	@echo "building..."
-	@$(docker_run) godep go install ./...
-	@make clean-generate
+	@$(docker_run) sh -c "make checks generate && \
+		godep go install ./... && \
+		make clean-generate"
 	@echo "done building..."
 
-unit-test: checks generate
+unit-test: build-docker-img
 	@echo "running unit-tests"
-	@$(docker_run) sh -c "godep go list -tags \"$(all_tags)\" ./... | xargs -n1 godep go test -tags $(unittest_tag)"
-	@make clean-generate
+	@$(docker_run) sh -c "make checks generate && \
+		godep go list -tags \"$(all_tags)\" ./... | xargs -n1 godep go test -tags $(unittest_tag) &&\
+		make clean-generate"
 	@echo "done running unit-tests"
 
 host-system-test: checks
@@ -74,11 +91,6 @@ system-test:
 	exit $${res}
 	@echo "done running system-tests"
 
-clean: deps
-	@echo "running clean"
-	@godep go clean -i -v ./...
-	@echo "done running clean"
-
 # We are using date based versioning, so for consistent version during a build
 # we evaluate and set the value of version once in a file and use it in 'tar'
 # and 'release' targets.
@@ -93,7 +105,7 @@ TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 tar: build
 	@echo "building tarball"
 	@echo "v0.0.0-`date -u +%m-%d-%Y.%H-%M-%S.UTC`" > $(VERSION_FILE)
-	@tar -jcf $(TAR_FILE) -C $(GOPATH)/bin clusterctl clusterm
+	@tar -jcf $(TAR_FILE) -C ./bin clusterctl clusterm
 	@echo "done building tarball"
 
 clean-tar:


### PR DESCRIPTION
As cluster-manager's build and test environment is mostly comprised of docker and vagrant,
this removes the redundant dependency of having go on the build hosts.