### PR TITLE
fail master node decommission of there are still worker nodes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,8 +61,8 @@ chown -R vagrant:vagrant #{gopath_dir}
 if [ "#{service_init}" = "false" ]; then
     echo mounting binaries from dev workspace
     rm -f /usr/bin/clusterm /usr/bin/clusterctl
-    ln -s #{gopath_dir}/src/github.com/contiv/clustermanagement/src/bin/clusterm /usr/bin/clusterm
-    ln -s #{gopath_dir}/src/github.com/contiv/clustermanagement/src/bin/clusterctl /usr/bin/clusterctl
+    ln -s #{gopath_dir}/src/github.com/contiv/cluster/management/src/bin/clusterm /usr/bin/clusterm
+    ln -s #{gopath_dir}/src/github.com/contiv/cluster/management/src/bin/clusterctl /usr/bin/clusterctl
 else
     echo using released binaries
 fi

--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -77,17 +77,18 @@ host-system-test: checks
 
 system-test:
 	@echo "running system-tests"
-	CONTIV_NODES=1 vagrant up; \
+	CONTIV_NODES=2 time vagrant up; \
 	time vagrant ssh cluster-node1 -c \
 	"export CONTIV_SOE=${CONTIV_SOE}; \
 	 export GOPATH=/opt/gopath/; \
 	 export PATH=\$$PATH:\$$GOPATH/bin; \
+	 export CONTIV_NODE_IPS='192.168.2.10,192.168.2.11'; \
 	 if [ \"${http_proxy}\" != \"\" ]; then export http_proxy=${http_proxy}; fi; \
 	 if [ \"${https_proxy}\" != \"\" ]; then export https_proxy=${https_proxy}; fi; \
 	 cd \$$GOPATH/src/github.com/contiv/cluster/management/src; \
 	 make host-system-test"; \
 	if [ "$$?" != "0" ]; then res=1; else res=0; fi; \
-	if [ "$${res}" = "0" -o "${CONTIV_SOE}" = "" ]; then CONTIV_NODES=1 vagrant destroy -f; fi; \
+	if [ "$${res}" = "0" -o "${CONTIV_SOE}" = "" ]; then CONTIV_NODES=2 vagrant destroy -f; fi; \
 	exit $${res}
 	@echo "done running system-tests"
 

--- a/management/src/clusterm/manager/utils.go
+++ b/management/src/clusterm/manager/utils.go
@@ -1,0 +1,61 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/contiv/cluster/management/src/inventory"
+)
+
+func nodeNotExistsError(name string) error {
+	return fmt.Errorf("node with name %q doesn't exists", name)
+}
+
+func nodeConfigNotExistsError(name string) error {
+	return fmt.Errorf("the configuration info for node %q doesn't exist", name)
+}
+
+func nodeInventoryNotExistsError(name string) error {
+	return fmt.Errorf("the inventory info for node %q doesn't exist", name)
+}
+
+func (m *Manager) findNode(name string) (*node, error) {
+	n, ok := m.nodes[name]
+	if !ok {
+		return nil, nodeNotExistsError(name)
+	}
+	return n, nil
+}
+
+func (m *Manager) isMasterNode(name string) (bool, error) {
+	n, err := m.findNode(name)
+	if err != nil {
+		return false, err
+	}
+	if n.cInfo == nil {
+		return false, nodeConfigNotExistsError(name)
+	}
+	return n.cInfo.GetGroup() == ansibleMasterGroupName, nil
+}
+
+func (m *Manager) isWorkerNode(name string) (bool, error) {
+	n, err := m.findNode(name)
+	if err != nil {
+		return false, err
+	}
+	if n.cInfo == nil {
+		return false, nodeConfigNotExistsError(name)
+	}
+	return n.cInfo.GetGroup() == ansibleWorkerGroupName, nil
+}
+
+func (m *Manager) isDiscoveredAndAllocatedNode(name string) (bool, error) {
+	n, err := m.findNode(name)
+	if err != nil {
+		return false, err
+	}
+	if n.iInfo == nil {
+		return false, nodeInventoryNotExistsError(name)
+	}
+	status, state := n.iInfo.GetStatus()
+	return state == inventory.Discovered && status == inventory.Allocated, nil
+}


### PR DESCRIPTION
Changes:
- Added a check in cluster manager to not decommision master node if there are still worker nodes
- Added a system test for this scenario
- Added some utility functions to improve readability
- fixed the path of dev binaries in Vagrantfile