### PR TITLE
Add a REST endpoint to post/get ansibl extra variables at gloabl level

### DIFF
--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -16,6 +16,11 @@ unittest_tag:=unittest
 systemtest_tag:=systemtest
 all_tags:=$(unittest_tag) $(systemtest_tag)
 
+# set CONTIV_TEST_FLAGS in environment to run specific system tests
+# Eg. CONTIV_TEST_FLAGS="-check.f=TestDecommission*"
+CONTIV_TEST_FLAGS:= \
+	$(if $(CONTIV_TEST_FLAGS),"$(CONTIV_TEST_FLAGS)", "")
+
 deps:
 	@echo "checking and downloading dependencies"
 	@go get github.com/tools/godep
@@ -68,12 +73,12 @@ build: build-docker-img
 unit-test: build-docker-img
 	@echo "running unit-tests"
 	@$(docker_run) sh -c "make checks generate && \
-		godep go list -tags \"$(all_tags)\" ./... | xargs -n1 godep go test -tags $(unittest_tag) &&\
+		godep go list -tags \"$(all_tags)\" ./... | xargs -n1 godep go test -tags $(unittest_tag) -check.v $(CONTIV_TEST_FLAGS) &&\
 		make clean-generate"
 	@echo "done running unit-tests"
 
 host-system-test: checks
-	@godep go test -v -tags $(systemtest_tag) github.com/contiv/cluster/management/src/systemtests -check.v
+	@godep go test -v -tags $(systemtest_tag) github.com/contiv/cluster/management/src/systemtests -check.v $(CONTIV_TEST_FLAGS)
 
 system-test:
 	@echo "running system-tests"
@@ -86,7 +91,7 @@ system-test:
 	 if [ \"${http_proxy}\" != \"\" ]; then export http_proxy=${http_proxy}; fi; \
 	 if [ \"${https_proxy}\" != \"\" ]; then export https_proxy=${https_proxy}; fi; \
 	 cd \$$GOPATH/src/github.com/contiv/cluster/management/src; \
-	 make host-system-test"; \
+	 CONTIV_TEST_FLAGS=$(CONTIV_TEST_FLAGS) make host-system-test"; \
 	if [ "$$?" != "0" ]; then res=1; else res=0; fi; \
 	if [ "$${res}" = "0" -o "${CONTIV_SOE}" = "" ]; then CONTIV_NODES=2 vagrant destroy -f; fi; \
 	exit $${res}

--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -12,6 +12,8 @@ docker_buildargs := \
 docker_img := cluster-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 docker_run:=docker run --rm -u `id -un`:`id -un` -v `pwd`:$(work_dir) \
 	-w $(work_dir) "$(docker_img)"
+docker_run_interactive:=docker run -it --rm -u `id -un`:`id -un` -v `pwd`:$(work_dir) \
+	-w $(work_dir) "$(docker_img)"
 unittest_tag:=unittest
 systemtest_tag:=systemtest
 all_tags:=$(unittest_tag) $(systemtest_tag)
@@ -60,25 +62,31 @@ check-code:
 build-docker-img:
 	docker build -t "$(docker_img)" $(docker_buildargs) .
 
-build-docker-shell:
-	@$(docker_run) bash
+build-docker-shell: build-docker-img
+	@$(docker_run_interactive) bash
 
 build: build-docker-img
-	@echo "building..."
-	@$(docker_run) sh -c "make checks generate && \
+	@echo "building test image..."
+	@$(docker_run) bash -c "make checks generate && \
 		godep go install ./... && \
 		make clean-generate"
-	@echo "done building..."
+	@echo "done building test image..."
 
 unit-test: build-docker-img
 	@echo "running unit-tests"
-	@$(docker_run) sh -c "make checks generate && \
-		godep go list -tags \"$(all_tags)\" ./... | xargs -n1 godep go test -tags $(unittest_tag) -check.v $(CONTIV_TEST_FLAGS) &&\
+	@$(docker_run) bash -c "make checks generate && \
+		(godep go list -tags '$(unittest_tag)' -f '{{.ImportPath}}:{{.TestGoFiles}}' ./... | \
+		grep -v '\[\]' | \
+		awk -F: '{print \$$1}' | \
+		xargs -n1 -I'{}' godep go test -tags '$(unittest_tag)' '{}' -check.v $(CONTIV_TEST_FLAGS)) && \
 		make clean-generate"
 	@echo "done running unit-tests"
 
 host-system-test: checks
-	@godep go test -v -tags $(systemtest_tag) github.com/contiv/cluster/management/src/systemtests -check.v $(CONTIV_TEST_FLAGS)
+	@godep go list -tags '$(systemtest_tag)'  -f '{{.ImportPath}}:{{.TestGoFiles}}' ./... | \
+		grep -v '\[\]' | \
+		awk -F: '{print $$1}' | \
+		xargs -n1 -I'{}' godep go test -tags '$(systemtest_tag)' '{}' -check.v $(CONTIV_TEST_FLAGS)
 
 system-test:
 	@echo "running system-tests"

--- a/management/src/clusterm/main_test.go
+++ b/management/src/clusterm/main_test.go
@@ -1,3 +1,5 @@
+// +build unittest
+
 package main
 
 import (

--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -91,6 +91,11 @@ func (c *Client) PostNodeInMaintenance(nodeName, extraVars string) error {
 	return c.doPost(fmt.Sprintf("%s/%s", PostNodeMaintenancePrefix, nodeName), extraVars)
 }
 
+// PostGlobals posts the request to set global extra vars
+func (c *Client) PostGlobals(extraVars string) error {
+	return c.doPost(fmt.Sprintf("%s", PostGlobals), extraVars)
+}
+
 // GetNode requests info of a specified node
 func (c *Client) GetNode(nodeName string) ([]byte, error) {
 	return c.doGet(fmt.Sprintf("%s/%s", GetNodeInfoPrefix, nodeName))
@@ -99,4 +104,9 @@ func (c *Client) GetNode(nodeName string) ([]byte, error) {
 // GetAllNodes requests info of all known nodes
 func (c *Client) GetAllNodes() ([]byte, error) {
 	return c.doGet(GetNodesInfo)
+}
+
+// GetGlobals requests the value global extra vars
+func (c *Client) GetGlobals() ([]byte, error) {
+	return c.doGet(GetGlobals)
 }

--- a/management/src/clusterm/manager/client_test.go
+++ b/management/src/clusterm/manager/client_test.go
@@ -162,6 +162,37 @@ func (s *managerSuite) TestPostInMaintenanceWithVarsSuccess(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *managerSuite) TestPostGlobalsWithVarsSuccess(c *C) {
+	expURLStr := fmt.Sprintf("http://%s/%s?%s=%s",
+		baseURL, PostGlobals, ExtraVarsQuery, testExtraVars)
+	expURL, err := url.Parse(expURLStr)
+	c.Assert(err, IsNil)
+	httpS, httpC := getHTTPTestClientAndServer(c, okReturner(c, expURL))
+	defer httpS.Close()
+	clstrC := Client{
+		url:   baseURL,
+		httpC: httpC,
+	}
+
+	err = clstrC.PostGlobals(testExtraVars)
+	c.Assert(err, IsNil)
+}
+
+func (s *managerSuite) TestPostGlobalsWithEmptyVarsSuccess(c *C) {
+	expURLStr := fmt.Sprintf("http://%s/%s", baseURL, PostGlobals)
+	expURL, err := url.Parse(expURLStr)
+	c.Assert(err, IsNil)
+	httpS, httpC := getHTTPTestClientAndServer(c, okReturner(c, expURL))
+	defer httpS.Close()
+	clstrC := Client{
+		url:   baseURL,
+		httpC: httpC,
+	}
+
+	err = clstrC.PostGlobals("")
+	c.Assert(err, IsNil)
+}
+
 func (s *managerSuite) TestPostError(c *C) {
 	expURLStr := fmt.Sprintf("http://%s/%s/%s", baseURL, PostNodeMaintenancePrefix, nodeName)
 	expURL, err := url.Parse(expURLStr)
@@ -205,6 +236,22 @@ func (s *managerSuite) TestGetNodesSuccess(c *C) {
 	}
 
 	resp, err := clstrC.GetNode(nodeName)
+	c.Assert(err, IsNil)
+	c.Assert(resp, DeepEquals, testGetData)
+}
+
+func (s *managerSuite) TestGetGlobalsSuccess(c *C) {
+	expURLStr := fmt.Sprintf("http://%s/%s", baseURL, GetGlobals)
+	expURL, err := url.Parse(expURLStr)
+	c.Assert(err, IsNil)
+	httpS, httpC := getHTTPTestClientAndServer(c, okGetReturner(c, expURL))
+	defer httpS.Close()
+	clstrC := Client{
+		url:   baseURL,
+		httpC: httpC,
+	}
+
+	resp, err := clstrC.GetGlobals()
 	c.Assert(err, IsNil)
 	c.Assert(resp, DeepEquals, testGetData)
 }

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -13,6 +13,9 @@ const (
 	// to put an asset in maintenance
 	PostNodeMaintenancePrefix = "maintenance/node"
 	postNodeMaintenance       = PostNodeMaintenancePrefix + "/{tag}"
+	// PostGlobals is the prefix for the POST REST endpoint
+	// to set global configuration values
+	PostGlobals = "globals"
 	// GetNodeInfoPrefix is the prefix for the GET REST endpoint
 	// to fetch info for an asset
 	GetNodeInfoPrefix = "info/node"
@@ -20,6 +23,9 @@ const (
 	// GetNodesInfo is the prefix for the GET REST endpoint
 	// to fetch info for all know assets
 	GetNodesInfo = "info/nodes"
+	// GetGlobals is the prefix for the GET REST endpoint
+	// to fetch the global configuration values
+	GetGlobals = "info/globals"
 	// ExtraVarsQuery is the key for the query variable used to specify the ansible extra
 	// variables for configuration actions. The variables shall be specified as a json map.
 	ExtraVarsQuery = "extra_vars"

--- a/management/src/configuration/ansible_test.go
+++ b/management/src/configuration/ansible_test.go
@@ -1,3 +1,5 @@
+// +build unittest
+
 package configuration
 
 import (

--- a/management/src/configuration/ansible_test.go
+++ b/management/src/configuration/ansible_test.go
@@ -1,0 +1,69 @@
+package configuration
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type ansibleSuite struct {
+}
+
+var _ = Suite(&ansibleSuite{})
+
+func (s *ansibleSuite) TestMergeExtraVarsSuccess(c *C) {
+	dst := `{
+		"foo": "bar",
+		"fooMap": {
+			"key1": "val1"
+		},
+		"keyReplace": "val"
+	}`
+	src := `{
+		"fooMap": {
+			"key2": "val2"
+		},
+		"keyReplace": "valReplace"
+	}`
+	//XXX: note that below the "fooMap" value is replaced than being merged. Do we
+	// need a merge here as well?
+	exptd := `{
+		"foo": "bar",
+		"fooMap": {
+			"key2": "val2"
+		},
+		"keyReplace": "valReplace"
+	}`
+
+	out, err := mergeExtraVars(dst, src)
+	c.Assert(err, IsNil)
+	var (
+		outMap   map[string]interface{}
+		exptdMap map[string]interface{}
+	)
+	c.Assert(json.Unmarshal([]byte(out), &outMap), IsNil)
+	c.Assert(json.Unmarshal([]byte(exptd), &exptdMap), IsNil)
+	c.Assert(outMap, DeepEquals, exptdMap)
+}
+
+func (s *ansibleSuite) TestMergeExtraVarsInvalidJSON(c *C) {
+	dst := `{
+		"foo": 
+	}`
+	src := `{}`
+	out, err := mergeExtraVars(dst, src)
+	c.Assert(err, ErrorMatches, "failed to unmarshal dest extra vars.*",
+		Commentf("output string: %s", out))
+
+	dst = `{}`
+	src = `{
+		"foo": 
+	}`
+	out, err = mergeExtraVars(dst, src)
+	c.Assert(err, ErrorMatches, "failed to unmarshal src extra vars.*",
+		Commentf("output string: %s", out))
+}

--- a/management/src/configuration/configuration.go
+++ b/management/src/configuration/configuration.go
@@ -9,8 +9,16 @@ type Subsys interface {
 	// Configure triggers the configuration logic on specified set of nodes.
 	// It return a error channel that the caller can wait on to get completion status.
 	Configure(nodes SubsysHosts, extraVars string) (io.Reader, chan error)
+	// Cleanup triggers the configuration cleanup on specified set of nodes.
+	// It return a error channel that the caller can wait on to get completion status.
 	Cleanup(nodes SubsysHosts, extraVars string) (io.Reader, chan error)
+	// Cleanup triggers the configuration upgrade on specified set of nodes.
+	// It return a error channel that the caller can wait on to get completion status.
 	Upgrade(nodes SubsysHosts, extraVars string) (io.Reader, chan error)
+	// SetGlobals sets the extra vars at a configuration subsys level
+	SetGlobals(extraVars string) error
+	// GetGlobals return the value of extra vars at a configuration subsys level
+	GetGlobals() string
 }
 
 // SubsysHost denotes a host in configuration subsystem

--- a/management/src/configuration/consts.go
+++ b/management/src/configuration/consts.go
@@ -1,0 +1,6 @@
+package configuration
+
+const (
+	// DefaultValidJSON is the default JSON used when extra vars is received as empty string
+	DefaultValidJSON = `{"env": {}}`
+)


### PR DESCRIPTION
This allows the user to specify common variable values just once. Note that the variables are not yet persisted across cluster-mgr, that shall be added in a subsequent PR. This fixes #50 

A few unrelated fixes include:
-  made minor fixes in Makefile to allow specifying testcase filter through the `CONTIV_TEST_FLAGS` env variable. This can be used to run a specific system or unit test while debugging issues.
- fixed the Vagrantfile provisioner logic to mount the dev binaries correctly.
- made decommission/commission test a bit more resillient by adding `drop_caches` to ensure that filesystem entries have been flushed before test verification.