### PR TITLE
vendor the recent ansible repo and a few fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -191,13 +191,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 node.vm.provision 'bootstrap-ansible', type: 'ansible' do |ansible|
                     ansible.groups = bootstrap_node_ansible_groups
                     ansible.playbook = ansible_playbook
-                    ansible.extra_vars = ansible_extra_vars
+                    ansible.extra_vars = ansible_extra_vars.clone
                     ansible.limit = 'all'
                 end
                 node.vm.provision 'main-ansible', type: 'ansible' do |ansible|
                     ansible.groups = ansible_groups
                     ansible.playbook = ansible_playbook
-                    ansible.extra_vars = ansible_extra_vars
+                    ansible.extra_vars = ansible_extra_vars.clone
                     # Turn off init cluster as this is a member-add scenario
                     ansible.extra_vars["etcd_init_cluster"] = false
                     ansible.limit = 'all'

--- a/management/src/configuration/consts.go
+++ b/management/src/configuration/consts.go
@@ -2,5 +2,5 @@ package configuration
 
 const (
 	// DefaultValidJSON is the default JSON used when extra vars is received as empty string
-	DefaultValidJSON = `{"env": {}}`
+	DefaultValidJSON = `{}`
 )

--- a/vendor/ansible/roles/contiv_cluster/defaults/main.yml
+++ b/vendor/ansible/roles/contiv_cluster/defaults/main.yml
@@ -5,7 +5,7 @@ collins_image: contiv/collins:02_25_2016
 collins_host_port: 9000
 collins_guest_port: 9000
 
-contiv_cluster_version: "v0.0.0-02-25-2016.02-31-37.UTC"
+contiv_cluster_version: "v0.0.0-03-08-2016.00-06-26.UTC"
 contiv_cluster_tar_file: "cluster-{{ contiv_cluster_version }}.tar.bz2"
 contiv_cluster_src_file: "https://github.com/contiv/cluster/releases/download/{{ contiv_cluster_version }}/{{ contiv_cluster_tar_file }}"
 contiv_cluster_dest_file: "/tmp/{{ contiv_cluster_tar_file }}"

--- a/vendor/ansible/roles/contiv_network/defaults/main.yml
+++ b/vendor/ansible/roles/contiv_network/defaults/main.yml
@@ -8,12 +8,12 @@ contiv_network_mode: "standalone" # Accepted values: standalone, aci
 netplugin_mode: "docker" # Accepted values: docker, kubernetes
 fwd_mode: "bridge" #Accepted values: bridge , routing
 
-contiv_network_version: "v0.1-02-27-2016.09-27-46.UTC"
+contiv_network_version: "v0.1-03-05-2016.09-42-48.UTC"
 contiv_network_tar_file: "netplugin-{{ contiv_network_version }}.tar.bz2"
 contiv_network_src_file: "https://github.com/contiv/netplugin/releases/download/{{ contiv_network_version }}/{{ contiv_network_tar_file }}"
 contiv_network_dest_file: "/tmp/{{ contiv_network_tar_file }}"
 
-contivctl_version: "v0.0.0-02-18-2016.22-10-53.UTC"
+contivctl_version: "v0.0.0-03-07-2016.23-26-25.UTC"
 contivctl_tar_file: "contivctl-{{ contivctl_version }}.tar.bz2"
 contivctl_src_file: "https://github.com/contiv/contivctl/releases/download/{{ contivctl_version }}/{{ contivctl_tar_file }}"
 contivctl_dest_file: "/tmp/{{ contivctl_tar_file }}"

--- a/vendor/ansible/roles/contiv_storage/defaults/main.yml
+++ b/vendor/ansible/roles/contiv_storage/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Role defaults for contiv_storage
 
-contiv_storage_version: "v0.0.0-02-25-2016.09-03-22.UTC"
+contiv_storage_version: "v0.0.0-03-07-2016.09-29-13.UTC"
 contiv_storage_tar_file: "volplugin-{{ contiv_storage_version }}.tar.bz2"
 contiv_storage_src_file: "https://github.com/contiv/volplugin/releases/download/{{ contiv_storage_version }}/{{ contiv_storage_tar_file }}"
 contiv_storage_dest_file: "/tmp/{{ contiv_storage_tar_file }}"

--- a/vendor/ansible/site.yml
+++ b/vendor/ansible/site.yml
@@ -59,11 +59,11 @@
   - { role: ucarp }
   - { role: docker }
   - { role: etcd, run_as: master }
-  - { role: ceph-mon, mon_group_name: service-master }
-  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master }
+  #- { role: ceph-mon, mon_group_name: service-master }
+  #- { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master }
   - { role: scheduler_stack, run_as: master }
   - { role: contiv_network, run_as: master }
-  - { role: contiv_storage, run_as: master }
+  #- { role: contiv_storage, run_as: master }
 
 # service-worker hosts correspond to cluster machines that run the worker/driver
 # logic of the infra services.
@@ -74,10 +74,10 @@
   - { role: base }
   - { role: docker }
   - { role: etcd, run_as: worker }
-  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker }
+  #- { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker }
   - { role: scheduler_stack, run_as: worker }
   - { role: contiv_network, run_as: worker }
-  - { role: contiv_storage, run_as: worker }
+  #- { role: contiv_storage, run_as: worker }
 
 # netplugin-node hosts set up netmast/netplugin in a cluster
 - hosts: netplugin-node


### PR DESCRIPTION
fixes: 
- use clone method on `ansible_extra_vars` in Vagrantfile to let each ansible provisioner have it's own copy and avoid failure during `vagrant provisions` due to both provisioners seeing same value.
- change `DefaulValidJSON` value to be empty JSON as otherwise when user doesn't specify a `extra-vars` during node commission, the default JSON was implicitly overriding the value provided by the user as part of `global` config.