### PR TITLE
Node Info REST endpoint returns info from all 3 subsystems

### DIFF
--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -37,7 +37,7 @@ checks: deps clean-generate check-format check-code
 generate: deps
 	@echo "auto generating files"
 	@mkdir -p mock
-	@go generate ./...
+	@godep go generate ./...
 	@echo "done auto generating files"
 
 clean-generate:
@@ -45,7 +45,7 @@ clean-generate:
 	@rm -f inventory/*_string.go
 	@rm -f clusterm/*_string.go
 	@rm -f monitor/*_string.go
-	@rm -f inventory/*_mock.go
+	@rm -f mock/*_mock.go
 	@echo "done cleaning auto-generated files"
 
 check-format:

--- a/management/src/clusterm/manager/api.go
+++ b/management/src/clusterm/manager/api.go
@@ -110,7 +110,6 @@ func (m *Manager) globalsSet(tag, extraVars string) error {
 
 func get(getCb func(tag string) ([]byte, error)) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		vars := mux.Vars(r)
 		tag := vars["tag"]
 		var (
@@ -128,19 +127,20 @@ func get(getCb func(tag string) ([]byte, error)) func(http.ResponseWriter, *http
 }
 
 func (m *Manager) oneNode(tag string) ([]byte, error) {
-	if a := m.inventory.GetAsset(tag); a != nil {
-		out, err := json.Marshal(a)
-		if err != nil {
-			return nil, err
-		}
-		return out, nil
+	node, err := m.findNode(tag)
+	if err != nil {
+		return nil, err
 	}
-	return []byte{}, nil
+
+	out, err := json.Marshal(node)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (m *Manager) allNodes(noop string) ([]byte, error) {
-	a := m.inventory.GetAllAssets()
-	out, err := json.Marshal(a)
+	out, err := json.Marshal(m.nodes)
 	if err != nil {
 		return nil, err
 	}

--- a/management/src/clusterm/manager/manager.go
+++ b/management/src/clusterm/manager/manager.go
@@ -63,9 +63,9 @@ func DefaultConfig() *Config {
 // node is an aggregate structure that contains information about a cluster
 // node as seen by cluster management subsystems.
 type node struct {
-	mInfo monitor.SubsysNode
-	iInfo inventory.SubsysAsset
-	cInfo configuration.SubsysHost
+	Mon monitor.SubsysNode       `json:"monitoring-state"`
+	Inv inventory.SubsysAsset    `json:"inventory-state"`
+	Cfg configuration.SubsysHost `json:"configuration-state"`
 }
 
 // Manager integrates the cluster infra services like node discovery, inventory

--- a/management/src/clusterm/manager/utils.go
+++ b/management/src/clusterm/manager/utils.go
@@ -32,11 +32,11 @@ func (m *Manager) isMasterNode(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if n.cInfo == nil {
+	if n.Cfg == nil {
 		return false, nodeConfigNotExistsError(name)
 	}
-	log.Debugf("node: %q, group: %q", name, n.cInfo.GetGroup())
-	return n.cInfo.GetGroup() == ansibleMasterGroupName, nil
+	log.Debugf("node: %q, group: %q", name, n.Cfg.GetGroup())
+	return n.Cfg.GetGroup() == ansibleMasterGroupName, nil
 }
 
 func (m *Manager) isWorkerNode(name string) (bool, error) {
@@ -44,11 +44,11 @@ func (m *Manager) isWorkerNode(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if n.cInfo == nil {
+	if n.Cfg == nil {
 		return false, nodeConfigNotExistsError(name)
 	}
-	log.Debugf("node: %q, group: %q", name, n.cInfo.GetGroup())
-	return n.cInfo.GetGroup() == ansibleWorkerGroupName, nil
+	log.Debugf("node: %q, group: %q", name, n.Cfg.GetGroup())
+	return n.Cfg.GetGroup() == ansibleWorkerGroupName, nil
 }
 
 func (m *Manager) isDiscoveredAndAllocatedNode(name string) (bool, error) {
@@ -56,10 +56,10 @@ func (m *Manager) isDiscoveredAndAllocatedNode(name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if n.iInfo == nil {
+	if n.Inv == nil {
 		return false, nodeInventoryNotExistsError(name)
 	}
-	status, state := n.iInfo.GetStatus()
+	status, state := n.Inv.GetStatus()
 	log.Debugf("node: %q, status: %q, state: %q", name, status, state)
 	return state == inventory.Discovered && status == inventory.Allocated, nil
 }

--- a/management/src/collins/client.go
+++ b/management/src/collins/client.go
@@ -1,3 +1,5 @@
+//go:generate mockgen -destination ../mock/collins_mock.go -package=mock github.com/contiv/cluster/management/src/collins InventoryClient
+
 package collins
 
 import (
@@ -34,6 +36,17 @@ type Asset struct {
 	State  struct {
 		Name string `json:"NAME"`
 	}
+}
+
+// InventoryClient provides the client interface for the collins inventory subsystem
+// XXX: this is to enable mock based unit-tests.
+type InventoryClient interface {
+	CreateAsset(tag, status string) error
+	GetAsset(tag string) (Asset, error)
+	GetAllAssets() ([]Asset, error)
+	CreateState(name, description, status string) error
+	AddAssetLog(tag, mtype, message string) error
+	SetAssetStatus(tag, status, state, reason string) error
 }
 
 // Client denotes state for a collins client

--- a/management/src/configuration/ansible.go
+++ b/management/src/configuration/ansible.go
@@ -66,6 +66,21 @@ func (h *AnsibleHost) SetGroup(group string) {
 	h.group = group
 }
 
+// MarshalJSON satisfies the json marshaller interface and shall encode asset info in json
+func (h *AnsibleHost) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Tag       string            `json:"inventory-name"`
+		HostGroup string            `json:"host-group"`
+		Addr      string            `json:"ssh-address"`
+		Vars      map[string]string `json:"inventory-vars"`
+	}{
+		Tag:       h.tag,
+		HostGroup: h.group,
+		Addr:      h.addr,
+		Vars:      h.vars,
+	})
+}
+
 // NewAnsibleSubsys instantiates and returns AnsibleSubsys
 func NewAnsibleSubsys(config *AnsibleSubsysConfig) *AnsibleSubsys {
 	return &AnsibleSubsys{

--- a/management/src/configuration/configuration.go
+++ b/management/src/configuration/configuration.go
@@ -1,6 +1,9 @@
 package configuration
 
-import "io"
+import (
+	"encoding/json"
+	"io"
+)
 
 // Subsys provides the following services to the cluster manager:
 // - Interface to trigger configuration action on one or more nodes, with
@@ -27,6 +30,8 @@ type SubsysHost interface {
 	GetTag() string
 	//GetGroup returns the group/role associated with the host in configuration sub-system
 	GetGroup() string
+	// SubsysHost shall satisfy the json marshaller interface to encode host's info in json
+	json.Marshaler
 }
 
 // SubsysHosts denotes a collection of hosts in configuration subsystem

--- a/management/src/inventory/asset.go
+++ b/management/src/inventory/asset.go
@@ -96,7 +96,7 @@ var lifecycleStates = map[AssetStatus]map[AssetState]bool{
 
 // Asset denotes a host or vm that is managed by the inventory susystem
 type Asset struct {
-	client     CollinsClient
+	client     collins.InventoryClient
 	name       string
 	status     AssetStatus
 	prevStatus AssetStatus
@@ -105,7 +105,7 @@ type Asset struct {
 }
 
 // NewAsset creates a new asset in the inventory in a discovered state and returns it.
-func NewAsset(client CollinsClient, name string) (*Asset, error) {
+func NewAsset(client collins.InventoryClient, name string) (*Asset, error) {
 	a := &Asset{
 		client:     client,
 		name:       name,
@@ -129,7 +129,7 @@ func NewAsset(client CollinsClient, name string) (*Asset, error) {
 }
 
 // NewAssetFromCollins creates an asset from state in collins and returns it.
-func NewAssetFromCollins(client CollinsClient, name string) (*Asset, error) {
+func NewAssetFromCollins(client collins.InventoryClient, name string) (*Asset, error) {
 	a := &Asset{
 		client:     client,
 		name:       name,

--- a/management/src/inventory/asset_test.go
+++ b/management/src/inventory/asset_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/contiv/cluster/management/src/collins"
+	"github.com/contiv/cluster/management/src/mock"
 	"github.com/golang/mock/gomock"
 	. "gopkg.in/check.v1"
 )
@@ -24,7 +25,7 @@ func (s *inventorySuite) TestNewAsset(c *C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	mClient := NewMockCollinsClient(ctrl)
+	mClient := mock.NewMockInventoryClient(ctrl)
 	eAsset := &Asset{
 		client:     mClient,
 		name:       "foo",
@@ -45,7 +46,7 @@ func (s *inventorySuite) TestNewAssetCreateFailure(c *C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	mClient := NewMockCollinsClient(ctrl)
+	mClient := mock.NewMockInventoryClient(ctrl)
 	eAsset := &Asset{
 		client:     mClient,
 		name:       "foo",
@@ -64,7 +65,7 @@ func (s *inventorySuite) TestNewAssetSetStatusFailure(c *C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	mClient := NewMockCollinsClient(ctrl)
+	mClient := mock.NewMockInventoryClient(ctrl)
 	eAsset := &Asset{
 		client:     mClient,
 		name:       "foo",
@@ -84,7 +85,7 @@ func (s *inventorySuite) TestNewAssetFromCollins(c *C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	mClient := NewMockCollinsClient(ctrl)
+	mClient := mock.NewMockInventoryClient(ctrl)
 	eAsset := &Asset{
 		client:     mClient,
 		name:       "foo",
@@ -111,7 +112,7 @@ func (s *inventorySuite) TestNewAssetFromCollinsGetFailure(c *C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	mClient := NewMockCollinsClient(ctrl)
+	mClient := mock.NewMockInventoryClient(ctrl)
 	eAsset := &Asset{
 		client:     mClient,
 		name:       "foo",
@@ -129,7 +130,7 @@ func (s *inventorySuite) TestSetStatus(c *C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	mClient := NewMockCollinsClient(ctrl)
+	mClient := mock.NewMockInventoryClient(ctrl)
 	asset := &Asset{
 		client:     mClient,
 		name:       "foo",
@@ -223,7 +224,7 @@ func (s *inventorySuite) TestSetStatusSetFailure(c *C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	mClient := NewMockCollinsClient(ctrl)
+	mClient := mock.NewMockInventoryClient(ctrl)
 	asset := &Asset{
 		client:     mClient,
 		name:       "foo",

--- a/management/src/inventory/collins.go
+++ b/management/src/inventory/collins.go
@@ -8,7 +8,7 @@ import (
 
 // CollinsSubsys implements the inventory sub-system for the collins inventory management database
 type CollinsSubsys struct {
-	client CollinsClient
+	client collins.InventoryClient
 	hosts  map[string]*Asset
 }
 

--- a/management/src/inventory/inventory.go
+++ b/management/src/inventory/inventory.go
@@ -1,8 +1,6 @@
-//go:generate mockgen -source $GOFILE -destination inventory_mock.go -package inventory -imports collins=github.com/contiv/cluster/management/src/collins
-
 package inventory
 
-import "github.com/contiv/cluster/management/src/collins"
+import "encoding/json"
 
 // Subsys provides the following services to the cluster manager:
 // - Interface to perform CRUD operations on the asset inventory.
@@ -35,20 +33,9 @@ type Subsys interface {
 type SubsysAsset interface {
 	//GetStatus return the current status of the asset
 	GetStatus() (AssetStatus, AssetState)
-	// MarshalJSON satisfies the json marshaller interface and shall encode asset info in json
-	MarshalJSON() ([]byte, error)
+	// SubsysAsset shall satisfy the json marshaller interface to encode asset's info in json
+	json.Marshaler
 }
 
 // SubsysAssets denotes a collection of assets in the inventory subsystem
 type SubsysAssets interface{}
-
-// CollinsClient provides the client interface for the inventory subsystem
-// XXX: this is to enable mock based unit-tests.
-type CollinsClient interface {
-	CreateAsset(tag, status string) error
-	GetAsset(tag string) (collins.Asset, error)
-	GetAllAssets() ([]collins.Asset, error)
-	CreateState(name, description, status string) error
-	AddAssetLog(tag, mtype, message string) error
-	SetAssetStatus(tag, status, state, reason string) error
-}

--- a/management/src/monitor/monitor.go
+++ b/management/src/monitor/monitor.go
@@ -1,5 +1,7 @@
 package monitor
 
+import "encoding/json"
+
 // Event is the state associate a node monitor event
 type Event struct {
 	Type EventType
@@ -31,6 +33,6 @@ type SubsysNode interface {
 	// GetAddress return the management address associated with the host. This address is
 	// used for pushing configuration to provision a host with cluster level services.
 	GetMgmtAddress() string
-	// MarshalJSON satisfies the json marshaller interface and shall encode asset info in json
-	MarshalJSON() ([]byte, error)
+	// SubsysNode shall satisfy the json marshaller interface to encode node's info in json
+	json.Marshaler
 }


### PR DESCRIPTION
fixes #43 

Also some misc fixes:
- moved the mock generation for collins client into collins package
- fixed an error with `http.WriteHeader()` being called twice in get REST api handler
- reverted the `drop_caches` change added in #52 as it doesn't work in vm environment