### PR TITLE
adding support for specifying host-group in extraVars

### DIFF
--- a/management/src/clusterm/manager/events.go
+++ b/management/src/clusterm/manager/events.go
@@ -335,6 +335,10 @@ func (e *nodeConfigure) process() error {
 		masterAddr = node.Mon.GetMgmtAddress()
 		masterName = node.Cfg.GetTag()
 		nodeGroup = ansibleWorkerGroupName
+
+		if groupName, err := e.mgr.fetchUserSpecifiedContivRole(e.extraVars); err == nil {
+			nodeGroup = groupName
+		}
 		break
 	}
 	hostInfo.SetGroup(nodeGroup)


### PR DESCRIPTION
added support for specifying host-group as a part of extraVars.
We can now specify the below in extraVars,

`"contiv_role": "service-master"`
`"contiv_role": "service-worker"`

If an unrecognised role is passed, we ignore the role and continue with the previous(default) behaviour.

The following nodes were provisioned using the above logic, so we have 3 masters and 3 workers
```
            "inventory-name": "ucsb-blade2-FCH1844JSV6",
            "host-group": "service-master",
--
            "inventory-name": "ucsb-blade3-FLM19145KXV",
            "host-group": "service-master",
--
            "inventory-name": "ucsb-blade4-FCH18517874",
            "host-group": "service-master",
--
            "inventory-name": "ucsb-osd1-FCH1951V212",
            "host-group": "service-worker",
--
            "inventory-name": "ucsb-osd2-FCH1951V0AV",
            "host-group": "service-worker",
--
            "inventory-name": "ucsb-osd3-FCH1951V20Y",
            "host-group": "service-worker",
```