### PR TITLE
Misc fixes and enhancements

### DIFF
--- a/management/README.md
+++ b/management/README.md
@@ -53,17 +53,16 @@ And info for a single node can be fetched by using `clusterctl node get <node-na
 clusterctl node commission <node-name>
 ```
 
-Commissioning a node involves pushing the configuration and starting infra service on that node using `ansible` based configuration management. Checkout the `service-master` and `service-worker` groups in [ansible/site.yml](../vendor/ansible/site.yml) to find out more about the serivces that configured. To quickly check if commisioning a node worked, you can run `etcdctl member list` on the node. It shall list all the commissioned members in the list.
+Commissioning a node involves pushing the configuration and starting infra services on that node using `ansible` based configuration management. Checkout the `service-master` and `service-worker` host-groups in [ansible/site.yml](../vendor/ansible/site.yml) to learn more about the services that are configured. To quickly check if commissioning a node worked, you can run `etcdctl member list` on the node. It shall list all the commissioned members in the list.
 
 **Note**:
-- certain ansible variables  need to be set for provisioning a node. The list of mandatory and other useful variables is provided in [ansible_vars.md](./ansible_vars.md). The variables need to be passed as a quoted JSON string in node commission command using the `--extra-vars` flag.
+- certain ansible variables need to be set for provisioning a node. The list of mandatory and other useful variables is provided in [ansible_vars.md](./ansible_vars.md). The variables need to be passed as a quoted JSON string in node commission command using the `--extra-vars` flag.
 ```
 clusterctl node commission node1 --extra-vars='{"env" : {"http_proxy": "my.proxy.url"}, "control_if": "eth2", "netplugin_if": "eth1" }'
 ```
-- a common set of variables (like environment info etc) can be set just once using `clusterctl global set` command with `--extra-vars` flag set.
-- The variables set at global level are merged with the variables specified as per node level, with latter taking precendence in case of an overlap/conflict.
+- a common set of variables (like environment) can be set just once as [global variables](#setget-global-variables). This eliminates the need to specify the common variables for every commission command.
 
-#### Decommision a node
+#### Decommission a node
 ```
 clusterctl node decommission <node-name>
 ```
@@ -77,9 +76,28 @@ clusterctl node maintain <node-name>
 
 Upgrading a node involves upgrading the configuration for infra services on that node using `ansible` based configuration management.
 
-#### Managing multiple nodes
+#### Set/Get global variables
+```
+clusterctl global set --extra-vars=<vars>
+```
+A common set of variables (like environment, scheduler-provider and so on) can be set just once using the `--extra-vars` flag with `clusterctl global set` command.
 
-**To be added**. This shall allow commission, decommission and rolling-upgrades of all or a subset of nodes.
+**Note**:
+- The variables need to be passed as a quoted JSON string using the `--extra-vars` flag.
+```
+clusterctl global set --extra-vars='{"env" : {"http_proxy": "my.proxy.url"}, "scheduler_provider": "ucp-swarm"}'
+```
+- The variables set at global level are merged with the variables specified at the node level, with the latter taking precendence in case of an overlap/conflict.
+- The list of useful variables is provided in [ansible_vars.md](./ansible_vars.md).
+
+#### Managing multiple nodes
+```
+clusterctl nodes commission <space separated node-name(s)>
+clusterctl nodes decommission <space separated node-name(s)>
+clusterctl nodes maintain <space separated node-name(s)>
+```
+
+The worflow to commission, decommission or upgrade all or a subset of nodes can be performed by using `clusterctl nodes` subcommands. Please refer the documentation of individual commands above for details.
 
 ##Want to learn more?
 Read the [design spec](DESIGN.md) and/or see the remaining/upcoming items in [roadmap](ROADMAP.md)

--- a/management/ansible_vars.md
+++ b/management/ansible_vars.md
@@ -1,6 +1,6 @@
 ##Ansible variables used during provisioning
 
-This file lists the ansible variables that can be passed at the time of commissioning a node or at a global level as described in [README.md](./README.md#commision-a-node). The ansible variables can also be passed at the time of setting up a node for discovery as described in [baremetal.md](./baremetal.md#3-provision-rest-of-the-nodes-for-discovery-from-the-control-host). The variables specified at global level are merged with variables specified for a node level operation, with latter taking precedence over the former in case of a overlap/conflict.
+This file lists the ansible variables that can be passed at the time of commissioning a node or at a global level as described in [README.md](./README.md#setget-global-variables). The ansible variables can also be passed at the time of setting up a node for discovery as described in [baremetal.md](./baremetal.md#3-provision-rest-of-the-nodes-for-discovery-from-the-control-host). The variables specified at global level are merged with variables specified for a node level operation, with latter taking precedence over the former in case of a overlap/conflict.
 
 Setting the variable at a global level that has same value across all nodes in a cluster, can substantially reduce the amount of variables that need to specified at every node level operation and is a recommended way to set the variables when possible.
 

--- a/management/baremetal.md
+++ b/management/baremetal.md
@@ -27,11 +27,13 @@ echo [cluster-control] > /tmp/hosts
 echo node1 ansible_host=127.0.0.1 >> /tmp/hosts
 
 # Install Cluster Manager service
-ansible-playbook --key-file=~/.ssh/id_rsa -i /tmp/hosts -e '{"env": {}}' ./site.yml
+ansible-playbook --key-file=~/.ssh/id_rsa -i /tmp/hosts -e '{"env": {}, "control_interface": "ifname"}' ./site.yml
 ```
 
 **Note**:
-- `env` is a mandatory variable. It is used to specify the environment for running ansible tasks like http-proxy. If there is no special environment to be setup then it needs to be set to an empty dictionary as shown in the example above.
+- `env` and `control_interface` need to be specified.
+- `env` is used to specify the environment for running ansible tasks like http-proxy. If there is no special environment to be setup then it needs to be set to an empty dictionary as shown in the example above.
+- `control_interface` is the netdevice that will carry serf traffic on this node.
 
 ###2. Configure the cluster manager service
 Edit the cluster manager configuration file that is created at `/etc/default/clusterm/clusterm.conf` to setup the user and playbook-location information. A sample is shown below. `playbook-location` needs to be set as the path of ansible directory we cloned in previous step. `user` needs to be set as name of `cluster-admin` user and `priv_key_file` is the location of the `id_rsa` file of `cluster-admin` user.
@@ -61,7 +63,7 @@ clusterctl discover <host-ip>
 
 **Note**:
 - Once the above command is run for a host, it will appear in `clusterctl nodes get` output in a few minutes.
-- the `clusterctl discover` command expects `env` and `control_interface` ansible variables to be specified. This can be achieved by using the `--extra-vars` flag or setting the variables at global level using `clusterctl global set` command. For more information on other available variables, also checkout [discovery section of ansible vars](ansible_vars.md#serf-based-discovery)
+- the `clusterctl discover` command expects `env` and `control_interface` ansible variables to be specified. This can be achieved by using the `--extra-vars` flag or setting them at [global level](README.md/#setget-global-variables), if applicable. For more information on other available variables, also checkout [discovery section of ansible vars](ansible_vars.md#serf-based-discovery)
 
 ###4. Ready to rock and roll!
 All set now, you can follow the cluster manager workflows as described [here](./README.md#get-list-of-discovered-nodes).

--- a/management/src/clusterm/manager/manager.go
+++ b/management/src/clusterm/manager/manager.go
@@ -61,7 +61,7 @@ func DefaultConfig() *Config {
 			PrivKeyFile:       "/vagrant/management/src/demo/files/insecure_private_key",
 		},
 		Manager: clustermConfig{
-			Addr: "0.0.0.0:9876",
+			Addr: "0.0.0.0:9007",
 		},
 	}
 }

--- a/management/src/systemtests/clusterm_test.go
+++ b/management/src/systemtests/clusterm_test.go
@@ -18,7 +18,7 @@ func (s *SystemTestSuite) TestClustermRestart(c *C) {
 	nodeName1 := validNodeNames[0]
 	nodeName2 := validNodeNames[1]
 
-	// commision the nodes. First node is master, second node is worker
+	// commission the nodes. First node is master, second node is worker
 	s.commissionNode(c, nodeName1, s.tbn1)
 	s.commissionNode(c, nodeName2, s.tbn2)
 


### PR DESCRIPTION
- **baremtal.md**: fix cluster installation command to show control_interface  . Fixes #105 
- **README.md**: document commands for multi-node workflow
- fix some typos in docs and code
- set default clusterm port as 9007 . Fixes #102 

I will update ansible to pull new cluster-manager release in a bit.

/cc @vvb 

/cc @rkharya: just fyi, the multi nodes support is in. And this PR updates some of the affected documentation. Let me know if you see any issues with the workflow.

/cc @vishal-j : the cluster-mgr API port is now 9007. Also the multi-node APIs are checked in. This will affect the UX. I will work on extra-vars related changes next but for now they are still passed as query-vals.