### PR TITLE
make demo target for clusterm only setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,23 +5,28 @@
 help: ## This help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-demo: stop start ## Bring up a demo setup. Tearsdown any existing setup first.
+demo: stop start ## Bring up a demo setup with all services started. This tearsdown any existing setup first.
 
-demo-stock: stop start-stock ## Bring up a demo setup with stock OS box. All packages are installed fresh. Useful for testing production like environment. Tearsdown any existing setup first.
+demo-cluster: stop start-cluster ## Bring up a demo setup with just clusterm running.  This is useful for trying out clusterm workflows. This tearsdown any existing setup first.
+
+demo-stock: stop start-stock ## Bring up a demo setup with stock OS box. All packages are installed fresh. This is useful for testing production like environment. This tearsdown any existing setup first.
 
 stop: ## Teardown a demo setup.
 	CONTIV_NODES=$${CONTIV_NODES:-3} vagrant destroy -f
 
-start: ## Bring up a demo setup.
-	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_SRV_INIT=1 vagrant up
+start: ## Bring up a demo setup with all services started.
+	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_REL_CLUSTERM=1 CONTIV_SRV_INIT=1 vagrant up
 
 start-stock: ## Bring up a demo setup with stock OS box. All packages are installed fresh. Useful for testing production like environment.
 	CONTIV_BOX="puppetlabs/centos-7.2-64-nocm" CONTIV_BOX_VERSION="1.0.1" make start
 
 svc-provision: ## Rerun ansible provisioning on the exisitng demo setup.
-	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_SRV_INIT=1 \
+	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_REL_CLUSTERM=1 CONTIV_SRV_INIT=1 \
 				 vagrant provision --provision-with ansible
 
 svc-cleanup: ## Run cleanup ansible on the existing demo setup.
 	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_ANSIBLE_PLAYBOOK="./vendor/ansible/cleanup.yml" \
 				 vagrant provision --provision-with ansible
+
+start-cluster: ## Bring up a demo setup with just clusterm running on first node. This is useful for trying out clusterm workflows.
+	CONTIV_NODES=$${CONTIV_NODES:-3} CONTIV_REL_CLUSTERM=1 vagrant up

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,12 @@ if ENV['CONTIV_SRV_INIT'] then
     service_init = true
 end
 
+clusterm_dev = true
+if ENV['CONTIV_REL_CLUSTERM'] then
+    # use released version of cluterm
+    clusterm_dev = false
+end
+
 box = "contiv/centos72"
 if ENV['CONTIV_BOX'] then
     box = ENV['CONTIV_BOX']
@@ -71,7 +77,7 @@ chown -R vagrant:vagrant #{gopath_dir}
 
 # if we are coming up in non-demo environment then load
 # the clusterm binaries from dev workspace
-if [ "#{service_init}" = "false" ]; then
+if [ "#{clusterm_dev}" = "true" ]; then
     echo mounting binaries from dev workspace
     rm -f /usr/bin/clusterm /usr/bin/clusterctl
     ln -s #{gopath_dir}/src/github.com/contiv/cluster/management/src/bin/clusterm /usr/bin/clusterm

--- a/management/README.md
+++ b/management/README.md
@@ -5,7 +5,6 @@ If you are trying cluster manager with baremetal hosts or a personal VM setup fo
 To try with a built-in vagrant based VM environment continue reading.
 
 ### 0. Ensure correct dependencies are installed
-- docker 1.9 or higher
 - vagrant 1.7.3 or higher
 - virtualbox 5.0 or higher
 - ansible 2.0 or higher
@@ -14,23 +13,14 @@ To try with a built-in vagrant based VM environment continue reading.
 ```
 cd $GOPATH/src/github.com/contiv/
 git clone https://github.com/contiv/cluster.git
-cd cluster/management/src
-make build
-```
-
-**Note**: `build` is run inside a docker container, so it requires docker to be installed
-and running on the host. To avoid having to use `sudo` for builds you can add the current
-user to `docker` group once by using the following command:
-```
-sudo usermod -a -G docker `id -un`
 ```
 
 ### 2. launch three vagrant nodes. 
 
 **Note:** If you look at the project's `Vagrantfile`, you will notice that all the vagrant nodes (except for the first node) boot up with stock centos7.2 OS and a `serf` agent running. `serf` is used as the node discovery service. This is intentional to meet the goal of limiting the amount of services that user needs to setup to start bringing up a cluster and hence making management easier.
 ```
-cd ../..
-CONTIV_NODES=3 vagrant up
+cd cluster/
+CONTIV_NODES=3 make demo-cluster
 ```
 
 ### 3. login to the first node to manage the cluster


### PR DESCRIPTION
added a new make target viz. `make demo-cluster`, to bring up a cluster of nodes and start clusterm on the first node. This shall help users quickly try out a released clusterm image without requiring a build.

Also updated the README.md to use the new target.

/cc @danehans . I think this shall help a cluster user to quickly try out workflows without having to deal with build.