### PR TITLE
adding support for specify host-group

### DIFF
--- a/management/README.md
+++ b/management/README.md
@@ -40,15 +40,15 @@ And info for a single node can be fetched by using `clusterctl node get <node-na
 
 #### Commision a node
 ```
-clusterctl node commission <node-name>
+clusterctl node commission <node-name> --host-group <service-master/service-worker>
 ```
 
-Commissioning a node involves pushing the configuration and starting infra services on that node using `ansible` based configuration management. Checkout the `service-master` and `service-worker` host-groups in [ansible/site.yml](../vendor/ansible/site.yml) to learn more about the services that are configured. To quickly check if commissioning a node worked, you can run `etcdctl member list` on the node. It shall list all the commissioned members in the list.
+Commissioning a node involves pushing the configuration and starting infra services on that node using `ansible` based configuration management. The services that are configured depend on the mandatory parameter `--host-group`. Checkout the `service-master` and `service-worker` host-groups in [ansible/site.yml](../vendor/ansible/site.yml) to learn more about the services that are configured. To quickly check if commissioning a node worked, you can run `etcdctl member list` on the node. It shall list all the commissioned members in the list.
 
 **Note**:
 - certain ansible variables need to be set for provisioning a node. The list of mandatory and other useful variables is provided in [ansible_vars.md](./ansible_vars.md). The variables need to be passed as a quoted JSON string in node commission command using the `--extra-vars` flag.
 ```
-clusterctl node commission node1 --extra-vars='{"env" : {"http_proxy": "my.proxy.url"}, "control_if": "eth2", "netplugin_if": "eth1" }'
+clusterctl node commission node1 --extra-vars='{"env" : {"http_proxy": "my.proxy.url"}, "control_if": "eth2", "netplugin_if": "eth1" }' --host-group "service-master"
 ```
 - a common set of variables (like environment) can be set just once as [global variables](#setget-global-variables). This eliminates the need to specify the common variables for every commission command.
 

--- a/management/src/clusterctl/main.go
+++ b/management/src/clusterctl/main.go
@@ -21,25 +21,31 @@ var (
 		},
 	}
 
-	extraVarsStringFlag = cli.StringFlag{
+	extraVarsFlag = cli.StringFlag{
 		Name:  "extra-vars, e",
 		Value: "",
 		Usage: "extra vars for ansible configuration. This should be a quoted json string.",
 	}
 
 	cmdFlags = []cli.Flag{
-		extraVarsStringFlag,
+		extraVarsFlag,
 	}
 
 	commissionFlags = []cli.Flag{
-		extraVarsStringFlag,
+		extraVarsFlag,
 		cli.StringFlag{
 			Name:  "host-group, g",
 			Value: "",
-			Usage: "host-group. service-master, service-worker",
+			Usage: "host-group of the node(s). Possible values: service-master or service-worker",
 		},
 	}
 )
+
+// parsedFlags is used to save cmdFlags
+type parsedFlags struct {
+	extraVars string
+	hostGroup string
+}
 
 func main() {
 	app := cli.NewApp()
@@ -172,12 +178,12 @@ func doAction(a actioner) func(*cli.Context) {
 	}
 }
 
-type postCallback func(c *manager.Client, args []string, flags manager.ActionFlags) error
+type postCallback func(c *manager.Client, args []string, flags parsedFlags) error
 type validateCallback func(args []string) error
 
 type postActioner struct {
 	args       []string
-	flags      manager.ActionFlags
+	flags      parsedFlags
 	validateCb validateCallback
 	postCb     postCallback
 }
@@ -190,11 +196,8 @@ func newPostActioner(validateCb validateCallback, postCb postCallback) *postActi
 }
 
 func (npa *postActioner) procFlags(c *cli.Context) {
-	npa.flags.ExtraVars = c.String("extra-vars")
-
-	// c.String returns "" if the flag does not exist
-	// so it is ok to include it without any checks
-	npa.flags.HostGroup = c.String("host-group")
+	npa.flags.extraVars = c.String("extra-vars")
+	npa.flags.hostGroup = c.String("host-group")
 }
 
 func (npa *postActioner) procArgs(c *cli.Context) {
@@ -215,19 +218,19 @@ func validateOneNodeName(args []string) error {
 	return nil
 }
 
-func nodeCommission(c *manager.Client, args []string, flags manager.ActionFlags) error {
+func nodeCommission(c *manager.Client, args []string, flags parsedFlags) error {
 	nodeName := args[0]
-	return c.PostNodeCommission(nodeName, flags)
+	return c.PostNodeCommission(nodeName, flags.extraVars, flags.hostGroup)
 }
 
-func nodeDecommission(c *manager.Client, args []string, flags manager.ActionFlags) error {
+func nodeDecommission(c *manager.Client, args []string, flags parsedFlags) error {
 	nodeName := args[0]
-	return c.PostNodeDecommission(nodeName, flags)
+	return c.PostNodeDecommission(nodeName, flags.extraVars)
 }
 
-func nodeMaintenance(c *manager.Client, args []string, flags manager.ActionFlags) error {
+func nodeMaintenance(c *manager.Client, args []string, flags parsedFlags) error {
 	nodeName := args[0]
-	return c.PostNodeInMaintenance(nodeName, flags)
+	return c.PostNodeInMaintenance(nodeName, flags.extraVars)
 }
 
 func validateMultiNodeNames(args []string) error {
@@ -237,16 +240,16 @@ func validateMultiNodeNames(args []string) error {
 	return nil
 }
 
-func nodesCommission(c *manager.Client, args []string, flags manager.ActionFlags) error {
-	return c.PostNodesCommission(args, flags)
+func nodesCommission(c *manager.Client, args []string, flags parsedFlags) error {
+	return c.PostNodesCommission(args, flags.extraVars, flags.hostGroup)
 }
 
-func nodesDecommission(c *manager.Client, args []string, flags manager.ActionFlags) error {
-	return c.PostNodesDecommission(args, flags)
+func nodesDecommission(c *manager.Client, args []string, flags parsedFlags) error {
+	return c.PostNodesDecommission(args, flags.extraVars)
 }
 
-func nodesMaintenance(c *manager.Client, args []string, flags manager.ActionFlags) error {
-	return c.PostNodesInMaintenance(args, flags)
+func nodesMaintenance(c *manager.Client, args []string, flags parsedFlags) error {
+	return c.PostNodesInMaintenance(args, flags.extraVars)
 }
 
 func validateMultiNodeAddrs(args []string) error {
@@ -261,8 +264,8 @@ func validateMultiNodeAddrs(args []string) error {
 	return nil
 }
 
-func nodesDiscover(c *manager.Client, args []string, flags manager.ActionFlags) error {
-	return c.PostNodesDiscover(args, flags)
+func nodesDiscover(c *manager.Client, args []string, flags parsedFlags) error {
+	return c.PostNodesDiscover(args, flags.extraVars)
 }
 
 func validateZeroArgs(args []string) error {
@@ -272,8 +275,8 @@ func validateZeroArgs(args []string) error {
 	return nil
 }
 
-func globalsSet(c *manager.Client, noop []string, flags manager.ActionFlags) error {
-	return c.PostGlobals(flags)
+func globalsSet(c *manager.Client, noop []string, flags parsedFlags) error {
+	return c.PostGlobals(flags.extraVars)
 }
 
 type getActioner struct {

--- a/management/src/clusterm/manager/api.go
+++ b/management/src/clusterm/manager/api.go
@@ -17,7 +17,7 @@ import (
 type APIRequest struct {
 	Nodes     []string `json:"nodes,omitempty"`
 	Addrs     []string `json:"addrs,omitempty"`
-	HostGroup string   `json:"hostgroup"`
+	HostGroup string   `json:"hostgroup,omitempty"`
 }
 
 // errInvalidJSON is the error returned when an invalid json value is specified for
@@ -73,39 +73,32 @@ func (m *Manager) apiLoop(errCh chan error) {
 	}
 }
 
-type postCallback func(tagsOrAddrs []string, flags ActionFlags) error
+type postCallback func(req *APIRequest, extraVars string) error
 
 func post(postCb postCallback) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		tagsOrAddrs := []string{}
-		var flags ActionFlags
-
 		// process data from request body, if any
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		req := APIRequest{}
 		if len(body) > 0 {
-			req := APIRequest{}
 			if err := json.Unmarshal(body, &req); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			// append both names and addresses if client specified both, invalid input will be
-			// handled as part of handler callback
-			tagsOrAddrs = append(tagsOrAddrs, req.Nodes...)
-			tagsOrAddrs = append(tagsOrAddrs, req.Addrs...)
-			flags.HostGroup = req.HostGroup
 		}
 
 		// process data from url, if any
 		vars := mux.Vars(r)
 		if vars["tag"] != "" {
-			tagsOrAddrs = append(tagsOrAddrs, vars["tag"])
+			req.Nodes = append(req.Nodes, vars["tag"])
 		}
 		if vars["addr"] != "" {
-			tagsOrAddrs = append(tagsOrAddrs, vars["addr"])
+			req.Addrs = append(req.Addrs, vars["addr"])
 		}
 
 		// process query variables
@@ -117,10 +110,9 @@ func post(postCb postCallback) http.HandlerFunc {
 				http.StatusInternalServerError)
 			return
 		}
-		flags.ExtraVars = sanitizedExtraVars
 
 		// call the handler
-		if err := postCb(tagsOrAddrs, flags); err != nil {
+		if err := postCb(&req, sanitizedExtraVars); err != nil {
 			http.Error(w,
 				err.Error(),
 				http.StatusInternalServerError)
@@ -145,35 +137,31 @@ func validateAndSanitizeEmptyExtraVars(errorPrefix, extraVars string) (string, e
 	return extraVars, nil
 }
 
-func (m *Manager) nodesCommission(tags []string, flags ActionFlags) error {
-	me := newWaitableEvent(newCommissionEvent(m, tags, flags))
+func (m *Manager) nodesCommission(req *APIRequest, extraVars string) error {
+	me := newWaitableEvent(newCommissionEvent(m, req.Nodes, extraVars, req.HostGroup))
 	m.reqQ <- me
 	return me.waitForCompletion()
 }
 
-func (m *Manager) nodesDecommission(tags []string, flags ActionFlags) error {
-	me := newWaitableEvent(newDecommissionEvent(m, tags, flags.ExtraVars))
+func (m *Manager) nodesDecommission(req *APIRequest, extraVars string) error {
+	me := newWaitableEvent(newDecommissionEvent(m, req.Nodes, extraVars))
 	m.reqQ <- me
 	return me.waitForCompletion()
 }
 
-func (m *Manager) nodesMaintenance(tags []string, flags ActionFlags) error {
-	me := newWaitableEvent(newMaintenanceEvent(m, tags, flags.ExtraVars))
+func (m *Manager) nodesMaintenance(req *APIRequest, extraVars string) error {
+	me := newWaitableEvent(newMaintenanceEvent(m, req.Nodes, extraVars))
 	m.reqQ <- me
 	return me.waitForCompletion()
 }
 
-func (m *Manager) nodesDiscover(addrs []string, flags ActionFlags) error {
-	me := newWaitableEvent(newDiscoverEvent(m, addrs, flags.ExtraVars))
+func (m *Manager) nodesDiscover(req *APIRequest, extraVars string) error {
+	me := newWaitableEvent(newDiscoverEvent(m, req.Addrs, extraVars))
 	m.reqQ <- me
 	return me.waitForCompletion()
 }
 
-func (m *Manager) globalsSet(noop []string, flags ActionFlags) error {
-	extraVars, err := validateAndSanitizeEmptyExtraVars(ExtraVarsQuery, flags.ExtraVars)
-	if err != nil {
-		return err
-	}
+func (m *Manager) globalsSet(req *APIRequest, extraVars string) error {
 	me := newWaitableEvent(newSetGlobalsEvent(m, extraVars))
 	m.reqQ <- me
 	return me.waitForCompletion()

--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -93,7 +93,7 @@ func (c *Client) doGet(rsrc string) ([]byte, error) {
 }
 
 // PostNodeCommission posts the request to commission a node
-func (c *Client) PostNodeCommission(nodeName string, extraVars string, hostGroup string) error {
+func (c *Client) PostNodeCommission(nodeName, extraVars, hostGroup string) error {
 	req := &APIRequest{
 		HostGroup: hostGroup,
 	}
@@ -101,7 +101,7 @@ func (c *Client) PostNodeCommission(nodeName string, extraVars string, hostGroup
 }
 
 // PostNodesCommission posts the request to commission a set of nodes
-func (c *Client) PostNodesCommission(nodeNames []string, extraVars string, hostGroup string) error {
+func (c *Client) PostNodesCommission(nodeNames []string, extraVars, hostGroup string) error {
 	req := &APIRequest{
 		Nodes:     nodeNames,
 		HostGroup: hostGroup,

--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -16,12 +16,6 @@ var httpErrorResp = func(rsrc string, req *APIRequest, status string, body []byt
 	return errored.Errorf("Request URL: %s Request Body: %+v Response status: %q. Response body: %s", rsrc, req, status, body)
 }
 
-// ActionFlags is used to save cmdFlags
-type ActionFlags struct {
-	ExtraVars string
-	HostGroup string
-}
-
 // Client provides the methods for issuing post and get requests to cluster manager
 type Client struct {
 	url   string
@@ -99,67 +93,59 @@ func (c *Client) doGet(rsrc string) ([]byte, error) {
 }
 
 // PostNodeCommission posts the request to commission a node
-func (c *Client) PostNodeCommission(nodeName string, flags ActionFlags) error {
-	if !IsValidHostGroup(flags.HostGroup) {
-		return errored.Errorf("host-group is a mandatory parameter and is not specified %s", flags.HostGroup)
-	}
-
+func (c *Client) PostNodeCommission(nodeName string, extraVars string, hostGroup string) error {
 	req := &APIRequest{
-		HostGroup: flags.HostGroup,
+		HostGroup: hostGroup,
 	}
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeCommissionPrefix, nodeName), flags.ExtraVars, req)
+	return c.doPost(fmt.Sprintf("%s/%s", PostNodeCommissionPrefix, nodeName), extraVars, req)
 }
 
 // PostNodesCommission posts the request to commission a set of nodes
-func (c *Client) PostNodesCommission(nodeNames []string, flags ActionFlags) error {
-	if !IsValidHostGroup(flags.HostGroup) {
-		return errored.Errorf("host-group is a mandatory parameter and is not specified %s", flags.HostGroup)
-	}
-
+func (c *Client) PostNodesCommission(nodeNames []string, extraVars string, hostGroup string) error {
 	req := &APIRequest{
 		Nodes:     nodeNames,
-		HostGroup: flags.HostGroup,
+		HostGroup: hostGroup,
 	}
-	return c.doPost(PostNodesCommission, flags.ExtraVars, req)
+	return c.doPost(PostNodesCommission, extraVars, req)
 }
 
 // PostNodeDecommission posts the request to decommission a node
-func (c *Client) PostNodeDecommission(nodeName string, flags ActionFlags) error {
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeDecommissionPrefix, nodeName), flags.ExtraVars, nil)
+func (c *Client) PostNodeDecommission(nodeName, extraVars string) error {
+	return c.doPost(fmt.Sprintf("%s/%s", PostNodeDecommissionPrefix, nodeName), extraVars, nil)
 }
 
 // PostNodesDecommission posts the request to decommission a set of nodes
-func (c *Client) PostNodesDecommission(nodeNames []string, flags ActionFlags) error {
+func (c *Client) PostNodesDecommission(nodeNames []string, extraVars string) error {
 	req := &APIRequest{
 		Nodes: nodeNames,
 	}
-	return c.doPost(PostNodesDecommission, flags.ExtraVars, req)
+	return c.doPost(PostNodesDecommission, extraVars, req)
 }
 
 // PostNodeInMaintenance posts the request to put a node in-maintenance
-func (c *Client) PostNodeInMaintenance(nodeName string, flags ActionFlags) error {
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeMaintenancePrefix, nodeName), flags.ExtraVars, nil)
+func (c *Client) PostNodeInMaintenance(nodeName, extraVars string) error {
+	return c.doPost(fmt.Sprintf("%s/%s", PostNodeMaintenancePrefix, nodeName), extraVars, nil)
 }
 
 // PostNodesInMaintenance posts the request to put a set of nodes in-maintenance
-func (c *Client) PostNodesInMaintenance(nodeNames []string, flags ActionFlags) error {
+func (c *Client) PostNodesInMaintenance(nodeNames []string, extraVars string) error {
 	req := &APIRequest{
 		Nodes: nodeNames,
 	}
-	return c.doPost(PostNodesMaintenance, flags.ExtraVars, req)
+	return c.doPost(PostNodesMaintenance, extraVars, req)
 }
 
 // PostNodesDiscover posts the request to provision a set of nodes for discovery
-func (c *Client) PostNodesDiscover(nodeAddrs []string, flags ActionFlags) error {
+func (c *Client) PostNodesDiscover(nodeAddrs []string, extraVars string) error {
 	req := &APIRequest{
 		Addrs: nodeAddrs,
 	}
-	return c.doPost(PostNodesDiscover, flags.ExtraVars, req)
+	return c.doPost(PostNodesDiscover, extraVars, req)
 }
 
 // PostGlobals posts the request to set global extra vars
-func (c *Client) PostGlobals(flags ActionFlags) error {
-	return c.doPost(PostGlobals, flags.ExtraVars, nil)
+func (c *Client) PostGlobals(extraVars string) error {
+	return c.doPost(PostGlobals, extraVars, nil)
 }
 
 // GetNode requests info of a specified node

--- a/management/src/clusterm/manager/commission_event.go
+++ b/management/src/clusterm/manager/commission_event.go
@@ -24,7 +24,7 @@ type commissionEvent struct {
 }
 
 // newCommissionEvent creates and returns commissionEvent
-func newCommissionEvent(mgr *Manager, nodeNames []string, extraVars string, hostGroup string) *commissionEvent {
+func newCommissionEvent(mgr *Manager, nodeNames []string, extraVars, hostGroup string) *commissionEvent {
 	return &commissionEvent{
 		mgr:       mgr,
 		nodeNames: nodeNames,
@@ -87,7 +87,7 @@ func (e *commissionEvent) process() error {
 func (e *commissionEvent) eventValidate() error {
 	var err error
 	if !IsValidHostGroup(e.hostGroup) {
-		return errored.Errorf("host-group is a mandatory parameter and is not specified %s", e.hostGroup)
+		return errored.Errorf("invalid or empty host-group specified: %q", e.hostGroup)
 	}
 
 	e._enodes, err = e.mgr.commonEventValidate(e.nodeNames)

--- a/management/src/clusterm/manager/commission_event.go
+++ b/management/src/clusterm/manager/commission_event.go
@@ -24,12 +24,12 @@ type commissionEvent struct {
 }
 
 // newCommissionEvent creates and returns commissionEvent
-func newCommissionEvent(mgr *Manager, nodeNames []string, flags ActionFlags) *commissionEvent {
+func newCommissionEvent(mgr *Manager, nodeNames []string, extraVars string, hostGroup string) *commissionEvent {
 	return &commissionEvent{
 		mgr:       mgr,
 		nodeNames: nodeNames,
-		extraVars: flags.ExtraVars,
-		hostGroup: flags.HostGroup,
+		extraVars: extraVars,
+		hostGroup: hostGroup,
 	}
 }
 
@@ -63,7 +63,7 @@ func (e *commissionEvent) process() error {
 	}()
 
 	// validate event data
-	if e._enodes, err = e.mgr.commonEventValidate(e.nodeNames); err != nil {
+	if err = e.eventValidate(); err != nil {
 		return err
 	}
 
@@ -82,6 +82,16 @@ func (e *commissionEvent) process() error {
 	go e.mgr.runActiveJob()
 
 	return nil
+}
+
+func (e *commissionEvent) eventValidate() error {
+	var err error
+	if !IsValidHostGroup(e.hostGroup) {
+		return errored.Errorf("host-group is a mandatory parameter and is not specified %s", e.hostGroup)
+	}
+
+	e._enodes, err = e.mgr.commonEventValidate(e.nodeNames)
+	return err
 }
 
 // prepareInventory takes care of assigning nodes to respective host-groups as part of

--- a/management/src/clusterm/manager/utils.go
+++ b/management/src/clusterm/manager/utils.go
@@ -147,3 +147,14 @@ func (m *Manager) runActiveJob() {
 	// reset the active job once done
 	m.resetActiveJob()
 }
+
+// IsValidHostGroup checks if the passed hostGroup is valid
+func IsValidHostGroup(hostGroup string) bool {
+	switch hostGroup {
+	case
+		ansibleMasterGroupName,
+		ansibleWorkerGroupName:
+		return true
+	}
+	return false
+}

--- a/management/src/systemtests/clusterm_test.go
+++ b/management/src/systemtests/clusterm_test.go
@@ -19,8 +19,8 @@ func (s *SystemTestSuite) TestClustermRestart(c *C) {
 	nodeName2 := validNodeNames[1]
 
 	// commission the nodes. First node is master, second node is worker
-	s.commissionNode(c, nodeName1, s.tbn1)
-	s.commissionNode(c, nodeName2, s.tbn2)
+	s.commissionNode(c, nodeName1, ansibleMasterGroupName, s.tbn1)
+	s.commissionNode(c, nodeName2, ansibleWorkerGroupName, s.tbn2)
 
 	// decommission one node
 	s.decommissionNode(c, nodeName2, s.tbn2)
@@ -40,13 +40,13 @@ func (s *SystemTestSuite) TestClustermFailureActiveJob(c *C) {
 	// launch commission on a node
 	done := make(chan struct{})
 	go func() {
-		s.commissionNode(c, nodeName1, s.tbn1)
+		s.commissionNode(c, nodeName1, ansibleMasterGroupName, s.tbn1)
 		done <- struct{}{}
 	}()
 
 	// try to start another commission job
 	time.Sleep(time.Second)
-	cmdStr := fmt.Sprintf("clusterctl node commission %s", nodeName2)
+	cmdStr := fmt.Sprintf("clusterctl node commission %s --host-group %s", nodeName2, ansibleWorkerGroupName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, NotNil, Commentf("output: %s", out))
 	exptStr := ".*there is already an active job.*"

--- a/management/src/systemtests/commission_test.go
+++ b/management/src/systemtests/commission_test.go
@@ -115,7 +115,6 @@ func (s *SystemTestSuite) TestCommissionNodeSerialMastersSuccess(c *C) {
 func (s *SystemTestSuite) TestCommissionNodesWithoutHostGroupFailure(c *C) {
 	nodeName := validNodeNames[0]
 
-	// commission a worker node directly
 	cmdStr := fmt.Sprintf("clusterctl nodes commission %s", nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, NotNil, Commentf("output: %s", out))
@@ -126,7 +125,6 @@ func (s *SystemTestSuite) TestCommissionNodesWithoutHostGroupFailure(c *C) {
 func (s *SystemTestSuite) TestCommissionNodeWithoutHostGroupFailure(c *C) {
 	nodeName := validNodeNames[0]
 
-	// commission a worker node directly
 	cmdStr := fmt.Sprintf("clusterctl node commission %s", nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, NotNil, Commentf("output: %s", out))

--- a/management/src/systemtests/commission_test.go
+++ b/management/src/systemtests/commission_test.go
@@ -118,7 +118,7 @@ func (s *SystemTestSuite) TestCommissionNodesWithoutHostGroupFailure(c *C) {
 	cmdStr := fmt.Sprintf("clusterctl nodes commission %s", nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, NotNil, Commentf("output: %s", out))
-	exptdOut := ".*host-group is a mandatory parameter and is not specified.*"
+	exptdOut := ".*invalid or empty host-group specified.*"
 	s.assertMatch(c, exptdOut, out)
 }
 
@@ -128,7 +128,7 @@ func (s *SystemTestSuite) TestCommissionNodeWithoutHostGroupFailure(c *C) {
 	cmdStr := fmt.Sprintf("clusterctl node commission %s", nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, NotNil, Commentf("output: %s", out))
-	exptdOut := ".*host-group is a mandatory parameter and is not specified.*"
+	exptdOut := ".*invalid or empty host-group specified.*"
 	s.assertMatch(c, exptdOut, out)
 }
 

--- a/management/src/systemtests/decommission_test.go
+++ b/management/src/systemtests/decommission_test.go
@@ -13,7 +13,7 @@ func (s *SystemTestSuite) TestDecommissionNodeSuccess(c *C) {
 	nodeName := validNodeNames[0]
 
 	// commission the node
-	s.commissionNode(c, nodeName, s.tbn1)
+	s.commissionNode(c, nodeName, ansibleMasterGroupName, s.tbn1)
 
 	// decommission the node
 	s.decommissionNode(c, nodeName, s.tbn1)
@@ -24,8 +24,8 @@ func (s *SystemTestSuite) TestDecommissionNodeSuccessSerial(c *C) {
 	nodeName2 := validNodeNames[1]
 
 	// commission the nodes. First node is master, second node is worker
-	s.commissionNode(c, nodeName1, s.tbn1)
-	s.commissionNode(c, nodeName2, s.tbn2)
+	s.commissionNode(c, nodeName1, ansibleMasterGroupName, s.tbn1)
+	s.commissionNode(c, nodeName2, ansibleWorkerGroupName, s.tbn2)
 
 	// decommission the node
 	s.decommissionNode(c, nodeName2, s.tbn2)
@@ -36,7 +36,7 @@ func (s *SystemTestSuite) TestDecommissionNodesSuccess(c *C) {
 	nodeNames := validNodeNames
 
 	// commission the nodes
-	s.commissionNodes(c, nodeNames)
+	s.commissionNodes(c, nodeNames, ansibleMasterGroupName)
 
 	// decommission the nodes
 	s.decommissionNodes(c, nodeNames)
@@ -47,8 +47,8 @@ func (s *SystemTestSuite) TestDecommissionNodeFailureRemainingWorker(c *C) {
 	nodeName2 := validNodeNames[1]
 
 	//commission the nodes. First node is master, second node is worker
-	s.commissionNode(c, nodeName1, s.tbn1)
-	s.commissionNode(c, nodeName2, s.tbn2)
+	s.commissionNode(c, nodeName1, ansibleMasterGroupName, s.tbn1)
+	s.commissionNode(c, nodeName2, ansibleWorkerGroupName, s.tbn2)
 
 	// decommission the master node
 	cmdStr := fmt.Sprintf("clusterctl node decommission %s", nodeName1)
@@ -63,7 +63,7 @@ func (s *SystemTestSuite) TestDecommissionNodesFailureDisappeared(c *C) {
 	nodeName := validNodeNames[1]
 
 	// commission the nodes
-	s.commissionNodes(c, nodeNames)
+	s.commissionNodes(c, nodeNames, ansibleMasterGroupName)
 
 	// make sure test node is visible in inventory
 	s.getNodeInfoSuccess(c, nodeName)
@@ -89,7 +89,7 @@ func (s *SystemTestSuite) TestDecommissionNodesFailureAlreadyDecommissioned(c *C
 	nodeNames := []string{secondNode, nodeName}
 
 	// commission the nodes
-	s.commissionNodes(c, nodeNames)
+	s.commissionNodes(c, nodeNames, ansibleMasterGroupName)
 
 	// decommission one node
 	s.decommissionNode(c, nodeName, s.tbn1)

--- a/management/src/systemtests/init_test.go
+++ b/management/src/systemtests/init_test.go
@@ -32,11 +32,13 @@ var _ = Suite(&SystemTestSuite{
 })
 
 var (
-	validNodeNames   = []string{"cluster-node1-0", "cluster-node2-0"}
-	validNodeAddrs   = []string{}
-	invalidNodeName  = "invalid-test-node"
-	dummyAnsibleFile = "/tmp/yay"
-	testDataDir      = os.Getenv("TESTDATA_DIR")
+	validNodeNames         = []string{"cluster-node1-0", "cluster-node2-0"}
+	validNodeAddrs         = []string{}
+	invalidNodeName        = "invalid-test-node"
+	dummyAnsibleFile       = "/tmp/yay"
+	testDataDir            = os.Getenv("TESTDATA_DIR")
+	ansibleMasterGroupName = "service-master"
+	ansibleWorkerGroupName = "service-worker"
 )
 
 func (s *SystemTestSuite) SetUpSuite(c *C) {

--- a/management/src/systemtests/utils.go
+++ b/management/src/systemtests/utils.go
@@ -152,9 +152,9 @@ func (s *SystemTestSuite) waitForSerfMembership(c *C, nut vagrantssh.TestbedNode
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 }
 
-func (s *SystemTestSuite) commissionNode(c *C, nodeName string, nut vagrantssh.TestbedNode) {
+func (s *SystemTestSuite) commissionNode(c *C, nodeName string, hostGroup string, nut vagrantssh.TestbedNode) {
 	// provision the node
-	cmdStr := fmt.Sprintf("clusterctl node commission %s", nodeName)
+	cmdStr := fmt.Sprintf("clusterctl node commission %s --host-group %s", nodeName, hostGroup)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 	s.checkProvisionStatus(c, s.tbn1, nodeName, "Allocated")
@@ -163,10 +163,10 @@ func (s *SystemTestSuite) commissionNode(c *C, nodeName string, nut vagrantssh.T
 	s.waitForStatToSucceed(c, nut, dummyAnsibleFile)
 }
 
-func (s *SystemTestSuite) commissionNodes(c *C, nodeNames []string) {
+func (s *SystemTestSuite) commissionNodes(c *C, nodeNames []string, hostGroup string) {
 	// provision the nodes
 	nodesStr := strings.Join(nodeNames, " ")
-	cmdStr := fmt.Sprintf("clusterctl nodes commission %s", nodesStr)
+	cmdStr := fmt.Sprintf("clusterctl nodes commission %s --host-group %s", nodesStr, hostGroup)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 	for _, name := range nodeNames {

--- a/management/src/systemtests/utils.go
+++ b/management/src/systemtests/utils.go
@@ -152,7 +152,7 @@ func (s *SystemTestSuite) waitForSerfMembership(c *C, nut vagrantssh.TestbedNode
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 }
 
-func (s *SystemTestSuite) commissionNode(c *C, nodeName string, hostGroup string, nut vagrantssh.TestbedNode) {
+func (s *SystemTestSuite) commissionNode(c *C, nodeName, hostGroup string, nut vagrantssh.TestbedNode) {
 	// provision the node
 	cmdStr := fmt.Sprintf("clusterctl node commission %s --host-group %s", nodeName, hostGroup)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)


### PR DESCRIPTION

PR for #87 
- added the necessary code to define the host-group flag in cli. for both `node` and `nodes` commission cases.
- added the guarding checks to make sure that host-group is mandatory from both cli and API
- check to make sure that workers cannot be provisioned before atleast one master node
- system tests for all the above.
- modified the system tests to take care of the necessary host-group parameter now.

what is not covered:
- the process to configure masters incrementally needs some thought in terms of service disruption and is not covered as a part of this PR.