### PR TITLE
increase systests timeout from 10m to 20m

### DIFF
--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -94,11 +94,11 @@ host-system-test: checks
 	@echo Running tests with BoltDB inventory
 	@$(systemtest_packages) | \
 		TESTDATA_DIR="demo/files/cli_test/boltdb/" xargs -n1 -I'{}' \
-		go test -tags '$(systemtest_tag)' '{}' -check.v $(CONTIV_TEST_FLAGS)
+		go test -timeout 20m -tags '$(systemtest_tag)' '{}' -check.v $(CONTIV_TEST_FLAGS)
 	@echo Running tests with collins inventory
 	@$(systemtest_packages) | \
 		TESTDATA_DIR="demo/files/cli_test/collins/" xargs -n1 -I'{}' \
-		go test -tags '$(systemtest_tag)' '{}' -check.v $(CONTIV_TEST_FLAGS)
+		go test -timeout 20m -tags '$(systemtest_tag)' '{}' -check.v $(CONTIV_TEST_FLAGS)
 
 system-test:
 	@echo "running system-tests"


### PR DESCRIPTION
system tests sometimes take slightly more than 10 mins and timeout. Hence increasing the timeout to 20m.

These were the times from my last run on one of the dev servers.
```
Running tests with BoltDB inventory
ok      github.com/contiv/cluster/management/src/systemtests    620.354s
Running tests with collins inventory
ok      github.com/contiv/cluster/management/src/systemtests    595.845s
```