### PR TITLE
extra-vars should be passed in the request body than as query-vars

### DIFF
--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/contiv/errored"
 )
@@ -27,16 +25,11 @@ func NewClient(url string) *Client {
 	return &Client{url: url, httpC: http.DefaultClient}
 }
 
-func (c *Client) formURL(rsrc, extraVars string) string {
-	if strings.TrimSpace(extraVars) == "" {
-		return fmt.Sprintf("http://%s/%s", c.url, rsrc)
-	}
-	v := url.Values{}
-	v.Set(ExtraVarsQuery, strings.TrimSpace(extraVars))
-	return fmt.Sprintf("http://%s/%s?%s", c.url, rsrc, v.Encode())
+func (c *Client) formURL(rsrc string) string {
+	return fmt.Sprintf("http://%s/%s", c.url, rsrc)
 }
 
-func (c *Client) doPost(rsrc, extraVars string, req *APIRequest) error {
+func (c *Client) doPost(rsrc string, req *APIRequest) error {
 
 	var reqJSON *bytes.Buffer
 	if req != nil {
@@ -54,9 +47,9 @@ func (c *Client) doPost(rsrc, extraVars string, req *APIRequest) error {
 		err  error
 	)
 	if reqJSON == nil {
-		resp, err = c.httpC.Post(c.formURL(rsrc, extraVars), "application/json", nil)
+		resp, err = c.httpC.Post(c.formURL(rsrc), "application/json", nil)
 	} else {
-		resp, err = c.httpC.Post(c.formURL(rsrc, extraVars), "application/json", reqJSON)
+		resp, err = c.httpC.Post(c.formURL(rsrc), "application/json", reqJSON)
 	}
 	if err != nil {
 		return err
@@ -75,7 +68,7 @@ func (c *Client) doPost(rsrc, extraVars string, req *APIRequest) error {
 
 // XXX: we should have a well defined structure for the info that is resturned
 func (c *Client) doGet(rsrc string) ([]byte, error) {
-	resp, err := c.httpC.Get(c.formURL(rsrc, ""))
+	resp, err := c.httpC.Get(c.formURL(rsrc))
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +89,9 @@ func (c *Client) doGet(rsrc string) ([]byte, error) {
 func (c *Client) PostNodeCommission(nodeName, extraVars, hostGroup string) error {
 	req := &APIRequest{
 		HostGroup: hostGroup,
+		ExtraVars: extraVars,
 	}
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeCommissionPrefix, nodeName), extraVars, req)
+	return c.doPost(fmt.Sprintf("%s/%s", PostNodeCommissionPrefix, nodeName), req)
 }
 
 // PostNodesCommission posts the request to commission a set of nodes
@@ -105,47 +99,60 @@ func (c *Client) PostNodesCommission(nodeNames []string, extraVars, hostGroup st
 	req := &APIRequest{
 		Nodes:     nodeNames,
 		HostGroup: hostGroup,
+		ExtraVars: extraVars,
 	}
-	return c.doPost(PostNodesCommission, extraVars, req)
+	return c.doPost(PostNodesCommission, req)
 }
 
 // PostNodeDecommission posts the request to decommission a node
 func (c *Client) PostNodeDecommission(nodeName, extraVars string) error {
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeDecommissionPrefix, nodeName), extraVars, nil)
+	req := &APIRequest{
+		ExtraVars: extraVars,
+	}
+	return c.doPost(fmt.Sprintf("%s/%s", PostNodeDecommissionPrefix, nodeName), req)
 }
 
 // PostNodesDecommission posts the request to decommission a set of nodes
 func (c *Client) PostNodesDecommission(nodeNames []string, extraVars string) error {
 	req := &APIRequest{
-		Nodes: nodeNames,
+		Nodes:     nodeNames,
+		ExtraVars: extraVars,
 	}
-	return c.doPost(PostNodesDecommission, extraVars, req)
+	return c.doPost(PostNodesDecommission, req)
 }
 
 // PostNodeInMaintenance posts the request to put a node in-maintenance
 func (c *Client) PostNodeInMaintenance(nodeName, extraVars string) error {
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeMaintenancePrefix, nodeName), extraVars, nil)
+	req := &APIRequest{
+		ExtraVars: extraVars,
+	}
+	return c.doPost(fmt.Sprintf("%s/%s", PostNodeMaintenancePrefix, nodeName), req)
 }
 
 // PostNodesInMaintenance posts the request to put a set of nodes in-maintenance
 func (c *Client) PostNodesInMaintenance(nodeNames []string, extraVars string) error {
 	req := &APIRequest{
-		Nodes: nodeNames,
+		Nodes:     nodeNames,
+		ExtraVars: extraVars,
 	}
-	return c.doPost(PostNodesMaintenance, extraVars, req)
+	return c.doPost(PostNodesMaintenance, req)
 }
 
 // PostNodesDiscover posts the request to provision a set of nodes for discovery
 func (c *Client) PostNodesDiscover(nodeAddrs []string, extraVars string) error {
 	req := &APIRequest{
-		Addrs: nodeAddrs,
+		Addrs:     nodeAddrs,
+		ExtraVars: extraVars,
 	}
-	return c.doPost(PostNodesDiscover, extraVars, req)
+	return c.doPost(PostNodesDiscover, req)
 }
 
 // PostGlobals posts the request to set global extra vars
 func (c *Client) PostGlobals(extraVars string) error {
-	return c.doPost(PostGlobals, extraVars, nil)
+	req := &APIRequest{
+		ExtraVars: extraVars,
+	}
+	return c.doPost(PostGlobals, req)
 }
 
 // GetNode requests info of a specified node


### PR DESCRIPTION
PR for #99 


(1) We now let the user specify the `extra-vars` as a part of the POST request body, than query-vars.
(2) All other interfaces are maintained how they originally were. Like interface towards the event related methods will still pass explicit arguments in a function call, rather than passing the `request` structure. 
(3) Refactored the unit-tests to bring some consistency to the variable names used. Had to modify some tests to take care of the `extra-vars` moving out of query-vars into request body.