### PR TITLE
add REST endpoint for posting monitor events

### DIFF
--- a/management/src/clusterm/manager/api.go
+++ b/management/src/clusterm/manager/api.go
@@ -60,7 +60,7 @@ func errInvalidEventName(event string) error {
 	return errored.Errorf("Invalid or empty event name specified: %q", event)
 }
 
-func (m *Manager) apiLoop(errCh chan error) {
+func (m *Manager) apiLoop(errCh chan error, servingCh chan struct{}) {
 	//set following headers for requests expecting a body
 	jsonContentHdrs := []string{"Content-Type", "application/json"}
 	//set following headers for requests that don't expect a body like get node info.
@@ -102,6 +102,10 @@ func (m *Manager) apiLoop(errCh chan error) {
 		errCh <- err
 		return
 	}
+
+	//signal that socket is being served
+	servingCh <- struct{}{}
+
 	if err := http.Serve(l, r); err != nil {
 		log.Errorf("Error listening for http requests. Error: %s", err)
 		errCh <- err

--- a/management/src/clusterm/manager/api_test.go
+++ b/management/src/clusterm/manager/api_test.go
@@ -1,0 +1,81 @@
+// +build unittest
+
+package manager
+
+import . "gopkg.in/check.v1"
+
+type apiSuite struct {
+}
+
+var (
+	_ = Suite(&apiSuite{})
+)
+
+// some POST handlers have static error checks, this test validates those
+func (s *apiSuite) TestPostHandlerErrorCase(c *C) {
+	m := Manager{}
+	tests := map[string]struct {
+		arg      *APIRequest
+		cb       postCallback
+		exptdErr error
+	}{
+		"monitor-event-invalid-name": {
+			cb: m.monitorEvent,
+			arg: &APIRequest{
+				Event: MonitorEvent{
+					Name: "foo",
+				},
+			},
+			exptdErr: errInvalidEventName("foo"),
+		},
+		"monitor-event-empty-name": {
+			cb: m.monitorEvent,
+			arg: &APIRequest{
+				Event: MonitorEvent{},
+			},
+			exptdErr: errInvalidEventName(""),
+		},
+	}
+
+	for key, test := range tests {
+		err := test.cb(test.arg)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error(), Equals, test.exptdErr.Error(), Commentf("key: %s", key))
+	}
+}
+
+// some Get handlers have static error checks, this test validates those
+func (s *apiSuite) TestGetHandlerErrorCase(c *C) {
+	m := Manager{}
+	tests := map[string]struct {
+		arg      *APIRequest
+		cb       getCallback
+		exptdErr error
+	}{
+		"job-invalid-label": {
+			cb: m.jobGet,
+			arg: &APIRequest{
+				Job: "foo",
+			},
+			exptdErr: errInvalidJobLabel("foo"),
+		},
+		"job-empty-label": {
+			cb:       m.jobGet,
+			arg:      &APIRequest{},
+			exptdErr: errInvalidJobLabel(""),
+		},
+		"job-non-existent": {
+			cb: m.jobGet,
+			arg: &APIRequest{
+				Job: "active",
+			},
+			exptdErr: errJobNotExist("active"),
+		},
+	}
+
+	for key, test := range tests {
+		_, err := test.cb(test.arg)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error(), Equals, test.exptdErr.Error(), Commentf("key: %s", key))
+	}
+}

--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -154,6 +154,17 @@ func (c *Client) PostGlobals(extraVars string) error {
 	return c.doPost(PostGlobals, req)
 }
 
+// PostMonitorEvent posts a monitor event for one or more nodes.
+func (c *Client) PostMonitorEvent(event string, nodes []MonitorNode) error {
+	req := &APIRequest{
+		Event: MonitorEvent{
+			Name:  event,
+			Nodes: nodes,
+		},
+	}
+	return c.doPost(PostMonitorEvent, req)
+}
+
 // GetNode requests info of a specified node
 func (c *Client) GetNode(nodeName string) ([]byte, error) {
 	return c.doGet(fmt.Sprintf("%s/%s", GetNodeInfoPrefix, nodeName))

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -38,6 +38,10 @@ const (
 	// to set global configuration values
 	PostGlobals = "globals"
 
+	// PostMonitorEvent is the prefix for the POST REST endpoint
+	// to post a monitor event for one or more nodes.
+	PostMonitorEvent = "monitor/event"
+
 	// GetNodeInfoPrefix is the prefix for the GET REST endpoint
 	// to fetch info for an asset
 	GetNodeInfoPrefix = "info/node"

--- a/management/src/clusterm/manager/disappeared_event.go
+++ b/management/src/clusterm/manager/disappeared_event.go
@@ -8,25 +8,25 @@ import (
 
 // disappearedEvent processes the disappeared event from monitoring subsystem
 type disappearedEvent struct {
-	mgr  *Manager
-	node monitor.SubsysNode
+	mgr   *Manager
+	nodes []monitor.SubsysNode
 }
 
 // newDisappearedEvent creates and returns disappearedEvent event
-func newDisappearedEvent(mgr *Manager, node monitor.SubsysNode) *disappearedEvent {
+func newDisappearedEvent(mgr *Manager, nodes []monitor.SubsysNode) *disappearedEvent {
 	return &disappearedEvent{
-		mgr:  mgr,
-		node: node,
+		mgr:   mgr,
+		nodes: nodes,
 	}
 }
 
 func (e *disappearedEvent) String() string {
-	return fmt.Sprintf("disappearedEvent: %+v", e.node)
+	return fmt.Sprintf("disappearedEvent: %+v", e.nodes[0])
 }
 
 func (e *disappearedEvent) process() error {
 	//XXX: need to form the name that adheres to collins tag requirements
-	name := e.node.GetLabel() + "-" + e.node.GetSerial()
+	name := e.nodes[0].GetLabel() + "-" + e.nodes[0].GetSerial()
 
 	node, err := e.mgr.findNode(name)
 	if err != nil {
@@ -34,7 +34,7 @@ func (e *disappearedEvent) process() error {
 	}
 
 	// update node's monitoring info to the one received in the event.
-	node.Mon = e.node
+	node.Mon = e.nodes[0]
 
 	if err := e.mgr.inventory.SetAssetDisappeared(name); err != nil {
 		// XXX. Log this to collins

--- a/management/src/clusterm/manager/manager.go
+++ b/management/src/clusterm/manager/manager.go
@@ -138,11 +138,12 @@ func NewManager(config *Config) (*Manager, error) {
 // Run triggers the manager loops
 func (m *Manager) Run(errCh chan error) {
 
-	// start monitor subsystem. It feeds node state monitoring events.
-	go m.monitorLoop(errCh)
-
 	// start http server for service REST api endpoints. It feeds api/ux events.
 	go m.apiLoop(errCh)
+
+	// start monitor subsystem. It feeds node state monitoring events.
+	// It needs to be started after api loop as monitor subsystem post events through API endpoints
+	go m.monitorLoop(errCh)
 
 	// start the event loop. It processes the events.
 	go m.eventLoop()

--- a/management/src/monitor/node.go
+++ b/management/src/monitor/node.go
@@ -9,6 +9,15 @@ type Node struct {
 	addr   string
 }
 
+// NewNode returns an instamce of node in monitoring subsystem
+func NewNode(label, serial, addr string) *Node {
+	return &Node{
+		label:  label,
+		serial: serial,
+		addr:   addr,
+	}
+}
+
 // GetLabel returns the label associated with the node in the monitoring system.
 // This is usually the hostname but can be anything more descriptive.
 func (n *Node) GetLabel() string {


### PR DESCRIPTION
Addresses #121 

Changes:
- added a `POST:monitor/event` REST endpoint.
  - This is slightly different from the proposal in a way that event name is not carried in the url but only in the request body.
- added client methods for posting monitor events
- made monitor event handlers accept multiple nodes
  - they still handle single node though. The change to handle multiple nodes will be added in subsequent PR.
- modified logic to post monitor events through the REST endpoint inplace of direct event injection
- Also added some more reliability fixes in job related unit tests
