### PR TITLE
make serf failure less disruptive and retry on failure

### DIFF
--- a/management/src/systemtests/clusterm_test.go
+++ b/management/src/systemtests/clusterm_test.go
@@ -62,3 +62,30 @@ func (s *SystemTestSuite) TestClustermFailureActiveJob(c *C) {
 	// try a decommission job once previous job is done
 	s.decommissionNode(c, nodeName1, s.tbn2)
 }
+
+func (s *SystemTestSuite) TestSerfFailureOnClustermHost(c *C) {
+	nodeName1 := validNodeNames[0]
+	nodeName2 := validNodeNames[1]
+
+	// make sure test node is visible in inventory
+	s.getNodeInfoSuccess(c, nodeName1)
+
+	// stop serf discovery on test node
+	s.stopSerf(c, s.tbn1)
+
+	// wait for serf membership to update
+	s.waitForSerfMembership(c, s.tbn2, nodeName1, "failed")
+
+	// make sure clusterm is up and running
+	s.checkClustermState(c, s.tbn1, "active")
+	s.commissionNode(c, nodeName2, ansibleMasterGroupName, s.tbn2)
+
+	// start serf discovery on test node
+	s.startSerf(c, s.tbn1)
+
+	// wait for serf membership to update
+	s.waitForSerfMembership(c, s.tbn2, nodeName1, "alive")
+
+	// make sure clusterm stays up and running
+	s.checkClustermState(c, s.tbn1, "active")
+}

--- a/management/src/systemtests/utils.go
+++ b/management/src/systemtests/utils.go
@@ -55,6 +55,12 @@ func (s *SystemTestSuite) restartClusterm(c *C, nut vagrantssh.TestbedNode, time
 	c.Logf("clusterm is running. %s", out)
 }
 
+func (s *SystemTestSuite) checkClustermState(c *C, nut vagrantssh.TestbedNode, state string) {
+	out, err := tutils.ServiceActionAndWaitForState(nut, "clusterm", 5, state,
+		func(vagrantssh.TestbedNode, string) (string, error) { return "noop", nil })
+	s.Assert(c, err, IsNil, Commentf("output: %s", out))
+}
+
 func (s *SystemTestSuite) nukeNodeInCollins(c *C, nodeName string) {
 	// Ignore errors here as asset might not exist.
 	out, err := s.tbn1.RunCommandWithOutput(fmt.Sprintf(`curl --basic -u blake:admin:first -d status="Decommissioned" -d reason="test" -X POST http://localhost:9000/api/asset/%s`, nodeName))


### PR DESCRIPTION
added logic to not error out if serf loop fails. The new logic retries to recover from failure when underlying serf issues resolve.

Fixes #28 
