### PR TITLE
make JSON tags consistents

### DIFF
--- a/management/baremetal.md
+++ b/management/baremetal.md
@@ -41,7 +41,7 @@ Edit the cluster manager configuration file that is created at `/etc/default/clu
 # cat /etc/default/clusterm/clusterm.conf
 {
     "ansible": {
-        "playbook-location": "/home/cluster-admin/ansible/",
+        "playbook_location": "/home/cluster-admin/ansible/",
         "user": "cluster-admin",
         "priv_key_file": "/home/cluster-admin/.ssh/id_rsa"
     }

--- a/management/src/clusterm/main_test.go
+++ b/management/src/clusterm/main_test.go
@@ -23,7 +23,7 @@ func (s *mainSuite) TestMergeConfigSuccess(c *C) {
 	dst := manager.DefaultConfig()
 	srcBytes := []byte(`{
 		"ansible" : {
-			"playbook-location" : "override-location"
+			"playbook_location" : "override-location"
 		}
 	}`)
 	exptdDst := manager.DefaultConfig()
@@ -95,7 +95,7 @@ func (s *mainSuite) TestMergeConfigInvalidJSON(c *C) {
 	dst := manager.DefaultConfig()
 	srcBytes := []byte(`{
 		"ansible" : {
-			"playbook-location" : "extra-comma-error",
+			"playbook_location" : "extra-comma-error",
 		}
 	}`)
 

--- a/management/src/clusterm/manager/api.go
+++ b/management/src/clusterm/manager/api.go
@@ -31,10 +31,10 @@ type MonitorEvent struct {
 type APIRequest struct {
 	Nodes     []string     `json:"nodes,omitempty"`
 	Addrs     []string     `json:"addrs,omitempty"`
-	HostGroup string       `json:"hostgroup,omitempty"`
-	ExtraVars string       `json:"extravars,omitempty"`
+	HostGroup string       `json:"host_group,omitempty"`
+	ExtraVars string       `json:"extra_vars,omitempty"`
 	Job       string       `json:"job,omitempty"`
-	Event     MonitorEvent `json:"monitor-event,omitempty"`
+	Event     MonitorEvent `json:"monitor_event,omitempty"`
 }
 
 // errInvalidJSON is the error returned when an invalid json value is specified for
@@ -142,7 +142,7 @@ func post(postCb postCallback) http.HandlerFunc {
 		}
 
 		// process query variables
-		req.ExtraVars, err = validateAndSanitizeEmptyExtraVars(ExtraVarsQuery, req.ExtraVars)
+		req.ExtraVars, err = validateAndSanitizeEmptyExtraVars("extra_vars", req.ExtraVars)
 		if err != nil {
 			http.Error(w,
 				err.Error(),
@@ -274,7 +274,7 @@ func (m *Manager) allNodes(noop *APIRequest) ([]byte, error) {
 func (m *Manager) globalsGet(noop *APIRequest) ([]byte, error) {
 	globals := m.configuration.GetGlobals()
 	globalData := struct {
-		ExtraVars map[string]interface{} `json:"extra-vars"`
+		ExtraVars map[string]interface{} `json:"extra_vars"`
 	}{
 		ExtraVars: make(map[string]interface{}),
 	}

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -60,10 +60,6 @@ const (
 	// 'active' or 'last'
 	GetJobPrefix = "info/job"
 	getJob       = GetJobPrefix + "/{job}"
-
-	// ExtraVarsQuery is the key for the query variable used to specify the ansible extra
-	// variables for configuration actions. The variables shall be specified as a json map.
-	ExtraVarsQuery = "extra_vars"
 )
 
 const (

--- a/management/src/clusterm/manager/manager.go
+++ b/management/src/clusterm/manager/manager.go
@@ -29,8 +29,8 @@ type clustermConfig struct {
 }
 
 type inventorySubsysConfig struct {
-	Collins *collins.Config `json:"collins,omit-empty"`
-	BoltDB  *boltdb.Config  `json:"boltdb,omit-empty"`
+	Collins *collins.Config `json:"collins,omitempty"`
+	BoltDB  *boltdb.Config  `json:"boltdb,omitempty"`
 }
 
 // Config is the configuration to cluster manager daemon
@@ -69,9 +69,9 @@ func DefaultConfig() *Config {
 // node is an aggregate structure that contains information about a cluster
 // node as seen by cluster management subsystems.
 type node struct {
-	Mon monitor.SubsysNode       `json:"monitoring-state"`
-	Inv inventory.SubsysAsset    `json:"inventory-state"`
-	Cfg configuration.SubsysHost `json:"configuration-state"`
+	Mon monitor.SubsysNode       `json:"monitoring_state"`
+	Inv inventory.SubsysAsset    `json:"inventory_state"`
+	Cfg configuration.SubsysHost `json:"configuration_state"`
 }
 
 // Manager integrates the cluster infra services like node discovery, inventory

--- a/management/src/configuration/ansible.go
+++ b/management/src/configuration/ansible.go
@@ -14,11 +14,11 @@ import (
 
 // AnsibleSubsysConfig describes the configuration for ansible based configuration management subsystem
 type AnsibleSubsysConfig struct {
-	ConfigurePlaybook string `json:"configure-playbook"`
-	CleanupPlaybook   string `json:"cleanup-playbook"`
-	UpgradePlaybook   string `json:"upgrade-playbook"`
-	PlaybookLocation  string `json:"playbook-location"`
-	ExtraVariables    string `json:"extra-variables"`
+	ConfigurePlaybook string `json:"configure_playbook"`
+	CleanupPlaybook   string `json:"cleanup_playbook"`
+	UpgradePlaybook   string `json:"upgrade_playbook"`
+	PlaybookLocation  string `json:"playbook_location"`
+	ExtraVariables    string `json:"extra_variables"`
 	// XXX: revisit the user credential configuration. We may need to allow other provisions.
 	User        string `json:"user"`
 	PrivKeyFile string `json:"priv_key_file"`
@@ -71,10 +71,10 @@ func (h *AnsibleHost) SetGroup(group string) {
 // MarshalJSON satisfies the json marshaller interface and shall encode asset info in json
 func (h *AnsibleHost) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Tag       string            `json:"inventory-name"`
-		HostGroup string            `json:"host-group"`
-		Addr      string            `json:"ssh-address"`
-		Vars      map[string]string `json:"inventory-vars"`
+		Tag       string            `json:"inventory_name"`
+		HostGroup string            `json:"host_group"`
+		Addr      string            `json:"ssh_address"`
+		Vars      map[string]string `json:"inventory_vars"`
 	}{
 		Tag:       h.tag,
 		HostGroup: h.group,

--- a/management/src/demo/files/cli_test/boltdb/clusterm.conf.json
+++ b/management/src/demo/files/cli_test/boltdb/clusterm.conf.json
@@ -1,5 +1,5 @@
 {
     "ansible": {
-        "playbook-location":  "/vagrant/management/src/demo/files"
+        "playbook_location":  "/vagrant/management/src/demo/files"
     }
 }

--- a/management/src/demo/files/cli_test/collins/clusterm.conf.json
+++ b/management/src/demo/files/cli_test/collins/clusterm.conf.json
@@ -1,6 +1,6 @@
 {
     "ansible": {
-        "playbook-location":  "/vagrant/management/src/demo/files"
+        "playbook_location":  "/vagrant/management/src/demo/files"
     },
     "inventory": {
         "collins": {

--- a/management/src/inventory/asset.go
+++ b/management/src/inventory/asset.go
@@ -189,9 +189,9 @@ func (a *Asset) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Name       string `json:"name"`
 		Status     string `json:"status"`
-		PrevStatus string `json:"prev-status"`
+		PrevStatus string `json:"prev_status"`
 		State      string `json:"state"`
-		PrevState  string `json:"prev-state"`
+		PrevState  string `json:"prev_state"`
 	}{
 		Name:       a.name,
 		Status:     a.status.String(),

--- a/management/src/monitor/node.go
+++ b/management/src/monitor/node.go
@@ -39,8 +39,8 @@ func (n *Node) GetMgmtAddress() string {
 func (n *Node) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Label       string `json:"label"`
-		Serial      string `json:"serial-number"`
-		MgmtAddress string `json:"management-address"`
+		Serial      string `json:"serial_number"`
+		MgmtAddress string `json:"management_address"`
 	}{
 		Label:       n.label,
 		Serial:      n.serial,

--- a/management/src/systemtests/clusterctl_test.go
+++ b/management/src/systemtests/clusterctl_test.go
@@ -40,10 +40,10 @@ func (s *SystemTestSuite) TestGetNodesInfoSuccess(c *C) {
 	cmdStr := `clusterctl nodes get`
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
-	exptdOut := `.*"monitoring-state":.*`
+	exptdOut := `.*"monitoring_state":.*`
 	s.assertMultiMatch(c, exptdOut, out, 2)
-	exptdOut = `.*"inventory-state":.*`
+	exptdOut = `.*"inventory_state":.*`
 	s.assertMultiMatch(c, exptdOut, out, 2)
-	exptdOut = `.*"configuration-state".*`
+	exptdOut = `.*"configuration_state".*`
 	s.assertMultiMatch(c, exptdOut, out, 2)
 }

--- a/management/src/systemtests/utils.go
+++ b/management/src/systemtests/utils.go
@@ -101,7 +101,7 @@ func (s *SystemTestSuite) checkProvisionStatus(c *C, tbn1 vagrantssh.TestbedNode
 }
 
 func (s *SystemTestSuite) checkHostGroup(c *C, nodeName, exptdGroup string) {
-	exptdStr := fmt.Sprintf(`.*"host-group".*"%s".*`, exptdGroup)
+	exptdStr := fmt.Sprintf(`.*"host_group".*"%s".*`, exptdGroup)
 	cmdStr := fmt.Sprintf("clusterctl node get %s", nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
@@ -214,10 +214,10 @@ func (s *SystemTestSuite) getNodeInfoSuccess(c *C, nodeName string) {
 	cmdStr := fmt.Sprintf(`clusterctl node get %s`, nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
-	exptdOut := `.*"monitoring-state":.*`
+	exptdOut := `.*"monitoring_state":.*`
 	s.assertMultiMatch(c, exptdOut, out, 1)
-	exptdOut = `.*"inventory-state":.*`
+	exptdOut = `.*"inventory_state":.*`
 	s.assertMultiMatch(c, exptdOut, out, 1)
-	exptdOut = `.*"configuration-state".*`
+	exptdOut = `.*"configuration_state".*`
 	s.assertMultiMatch(c, exptdOut, out, 1)
 }


### PR DESCRIPTION
clusterm follows the conventions of all lower case tags. And multi-word tags use underscore (_) as a separator.

/cc @vishal-j , this is per our UX discussion

/cc @rkharya , just fyi, please note the change in baremetals.md