### PR TITLE
Add template based printing for human readable command output

### DIFF
--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -77,7 +77,7 @@ build-docker-shell: build-docker-img
 
 build: build-docker-img
 	@echo "building test image..."
-	$(docker_run) bash -c "make checks generate && \
+	@$(docker_run) bash -c "make checks generate && \
 		($(all_packages) | xargs -n1 go install \
 		    -ldflags '-X main.version=$(if $(BUILD_VERSION),$(BUILD_VERSION),devbuild)') && \
 		make clean-generate"

--- a/management/src/clusterctl/commands.go
+++ b/management/src/clusterctl/commands.go
@@ -23,7 +23,16 @@ var (
 		Usage: "extra vars for ansible configuration. This should be a quoted json string.",
 	}
 
-	cmdFlags = []cli.Flag{
+	jsonFlag = cli.BoolFlag{
+		Name:  "json, j",
+		Usage: "print command output in JSON",
+	}
+
+	getFlags = []cli.Flag{
+		jsonFlag,
+	}
+
+	postFlags = []cli.Flag{
 		extraVarsFlag,
 	}
 
@@ -54,20 +63,21 @@ var (
 					Aliases: []string{"d"},
 					Usage:   "decommission a node",
 					Action:  doAction(newPostActioner(validateOneNodeName, nodeDecommission)),
-					Flags:   cmdFlags,
+					Flags:   postFlags,
 				},
 				{
 					Name:    "maintenance",
 					Aliases: []string{"m"},
 					Usage:   "put a node in maintenance",
 					Action:  doAction(newPostActioner(validateOneNodeName, nodeMaintenance)),
-					Flags:   cmdFlags,
+					Flags:   postFlags,
 				},
 				{
 					Name:    "get",
 					Aliases: []string{"g"},
 					Usage:   "get node's status information",
 					Action:  doAction(newGetActioner(nodeGet)),
+					Flags:   getFlags,
 				},
 			},
 		},
@@ -88,20 +98,21 @@ var (
 					Aliases: []string{"d"},
 					Usage:   "decommission a set of nodes",
 					Action:  doAction(newPostActioner(validateMultiNodeNames, nodesDecommission)),
-					Flags:   cmdFlags,
+					Flags:   postFlags,
 				},
 				{
 					Name:    "maintenance",
 					Aliases: []string{"m"},
 					Usage:   "put a set of nodes in maintenance",
 					Action:  doAction(newPostActioner(validateMultiNodeNames, nodesMaintenance)),
-					Flags:   cmdFlags,
+					Flags:   postFlags,
 				},
 				{
 					Name:    "get",
 					Aliases: []string{"g"},
 					Usage:   "get status information for all nodes",
 					Action:  doAction(newGetActioner(nodesGet)),
+					Flags:   getFlags,
 				},
 			},
 		},
@@ -115,13 +126,14 @@ var (
 					Aliases: []string{"g"},
 					Usage:   "get global info",
 					Action:  doAction(newGetActioner(globalsGet)),
+					Flags:   getFlags,
 				},
 				{
 					Name:    "set",
 					Aliases: []string{"s"},
 					Usage:   "set global info",
-					Flags:   cmdFlags,
 					Action:  doAction(newPostActioner(validateZeroArgs, globalsSet)),
+					Flags:   postFlags,
 				},
 			},
 		},
@@ -135,6 +147,7 @@ var (
 					Aliases: []string{"g"},
 					Usage:   "get job info. Expects an arg with value 'active' or 'last'",
 					Action:  doAction(newGetActioner(jobGet)),
+					Flags:   getFlags,
 				},
 			},
 		},
@@ -143,7 +156,7 @@ var (
 			Aliases: []string{"d"},
 			Usage:   "provision one or more nodes for discovery",
 			Action:  doAction(newPostActioner(validateMultiNodeAddrs, nodesDiscover)),
-			Flags:   cmdFlags,
+			Flags:   postFlags,
 		},
 	}
 )
@@ -154,6 +167,12 @@ func errUnexpectedArgCount(exptd string, rcvd int) error {
 
 func errInvalidIPAddr(a string) error {
 	return errored.Errorf("failed to parse ip address %q", a)
+}
+
+type parsedFlags struct {
+	extraVars  string
+	hostGroup  string
+	jsonOutput bool
 }
 
 type actioner interface {

--- a/management/src/clusterctl/get_actions.go
+++ b/management/src/clusterctl/get_actions.go
@@ -4,21 +4,136 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"reflect"
+	"text/template"
 
 	"github.com/codegangsta/cli"
 	"github.com/contiv/cluster/management/src/clusterm/manager"
 )
 
-type getActioner struct {
-	arg   string
-	getCb func(c *manager.Client, arg string) error
+type nodeInfo struct {
+	Mon map[string]interface{} `json:"monitoring_state"`
+	Inv map[string]interface{} `json:"inventory_state"`
+	Cfg map[string]interface{} `json:"configuration_state"`
 }
 
-func newGetActioner(getCb func(c *manager.Client, nodeName string) error) *getActioner {
+type nodesInfo map[string]nodeInfo
+
+type jobInfo map[string]interface{}
+
+type globalInfo map[string]interface{}
+
+// printHelper stores indent related metadat along with the value being printed
+type printHelper struct {
+	Indent string
+	Val    interface{}
+}
+
+func newPrintHelper(indent string, val interface{}) *printHelper {
+	return &printHelper{
+		Indent: indent,
+		Val:    val,
+	}
+}
+
+var (
+	typeFuncs = template.FuncMap{
+		"valueOf":        reflect.ValueOf,
+		"newPrintHelper": newPrintHelper,
+	}
+	typePrint = `
+{{- define "typePrint" }}
+	{{- $indent := .Indent }}
+	{{- $inVal := .Val }}
+	{{- with valueOf $inVal }}
+		{{- $type := .Kind.String }}
+		{{- if eq $type "map" }}
+			{{- template "mapPrint" newPrintHelper $indent $inVal }}
+		{{- else if eq $type "slice" }}
+			{{- template "slicePrint" newPrintHelper $indent $inVal }}
+		{{- else if eq $type "ptr" }}
+			{{- $val := .Elem.Interface }}
+			{{- template "typePrint" newPrintHelper $indent $val }}
+		{{- else }}
+			{{- $indent }}{{ $inVal }}{{ "\n" }}
+		{{- end }}
+	{{- end }}
+{{- end }}
+{{- define "slicePrint" }}
+	{{- $indent := .Indent }}
+	{{- $inVal := .Val }}
+	{{- range $idx, $elem := $inVal }}
+		{{- $indent }}{{ $elem }}{{ "\n" }}
+	{{- end }}
+{{- end }}
+{{- define "mapPrint" }}
+	{{- $indent := .Indent }}
+	{{- $inVal := .Val }}
+	{{- range $key, $val := $inVal }}
+		{{- with valueOf $val }}
+			{{- $type := .Kind.String }}
+			{{- if eq $type "map" }}
+				{{- $indent }}{{ $key }}:{{ "\n" }}
+				{{- $newIndent := printf "%s    " $indent }}{{ template "typePrint" newPrintHelper $newIndent $val }}
+			{{- else if eq $type "slice" }}
+				{{- $indent }}{{ $key }}:{{ "\n" }}
+				{{- $newIndent := printf "%s    " $indent }}{{ template "typePrint" newPrintHelper $newIndent $val }}
+			{{- else }}
+				{{- $indent }}{{ $key }}: {{ $val }}{{ "\n" }}
+			{{- end }}
+		{{- end }}
+	{{- end }}
+{{- end }}
+	`
+	typeTemplate = template.Must(template.New("").Funcs(typeFuncs).Parse(typePrint))
+
+	globalPrint    = `{{ template "typePrint" newPrintHelper "" .}}`
+	globalTemplate = template.Must(template.Must(typeTemplate.Clone()).Parse(globalPrint))
+
+	nodePrint = `
+{{- define "nodePrint" }}
+	{{- $invName := .Inv.name }}
+	{{- $indent := printf "%s:    " $invName }}
+	{{- $invName }}: Inventory State{{ "\n" }}
+	{{- template "typePrint" newPrintHelper $indent .Inv }}
+	{{- $invName }}: Monitoring State{{ "\n" }}
+	{{- template "typePrint" newPrintHelper $indent .Mon }}
+	{{- $invName }}: Configuration State{{ "\n" }}
+	{{- template "typePrint" newPrintHelper $indent .Cfg }}
+{{ end }}
+`
+	nodeTemplate = template.Must(template.Must(typeTemplate.Clone()).Parse(nodePrint))
+
+	oneNodePrint    = `{{- template "nodePrint" . }}`
+	oneNodeTemplate = template.Must(template.Must(nodeTemplate.Clone()).Parse(oneNodePrint))
+
+	multiNodePrint    = `{{- range $key, $val := . }}{{ template "nodePrint" $val }}{{ end }}`
+	multiNodeTemplate = template.Must(template.Must(nodeTemplate.Clone()).Parse(multiNodePrint))
+
+	jobPrint = `
+Description: {{ .desc }}
+Status: {{ .status }}
+Error: {{ .error }}
+Logs:
+{{ template "typePrint" newPrintHelper "    " .logs }}
+`
+	jobTemplate = template.Must(template.Must(typeTemplate.Clone()).Parse(jobPrint))
+)
+
+type getCallback func(c *manager.Client, arg string, flags parsedFlags) error
+
+type getActioner struct {
+	arg   string
+	flags parsedFlags
+	getCb getCallback
+}
+
+func newGetActioner(getCb getCallback) *getActioner {
 	return &getActioner{getCb: getCb}
 }
 
 func (nga *getActioner) procFlags(c *cli.Context) {
+	nga.flags.jsonOutput = c.Bool("json")
 	return
 }
 
@@ -27,7 +142,7 @@ func (nga *getActioner) procArgs(c *cli.Context) {
 }
 
 func (nga *getActioner) action(c *manager.Client) error {
-	return nga.getCb(c, nga.arg)
+	return nga.getCb(c, nga.arg, nga.flags)
 }
 
 func ppJSON(out []byte) {
@@ -36,7 +151,14 @@ func ppJSON(out []byte) {
 	outBuf.WriteTo(os.Stdout)
 }
 
-func nodeGet(c *manager.Client, nodeName string) error {
+func printTemplate(out []byte, t *template.Template, i interface{}) error {
+	if err := json.Unmarshal(out, i); err != nil {
+		return err
+	}
+	return t.Execute(os.Stdout, i)
+}
+
+func nodeGet(c *manager.Client, nodeName string, flags parsedFlags) error {
 	if nodeName == "" {
 		return errUnexpectedArgCount("1", 0)
 	}
@@ -46,31 +168,43 @@ func nodeGet(c *manager.Client, nodeName string) error {
 		return err
 	}
 
+	if !flags.jsonOutput {
+		return printTemplate(out, oneNodeTemplate, &nodeInfo{})
+	}
+
 	ppJSON(out)
 	return nil
 }
 
-func nodesGet(c *manager.Client, noop string) error {
+func nodesGet(c *manager.Client, noop string, flags parsedFlags) error {
 	out, err := c.GetAllNodes()
 	if err != nil {
 		return err
 	}
 
-	ppJSON(out)
-	return nil
-}
-
-func globalsGet(c *manager.Client, noop string) error {
-	out, err := c.GetGlobals()
-	if err != nil {
-		return err
+	if !flags.jsonOutput {
+		return printTemplate(out, multiNodeTemplate, &nodesInfo{})
 	}
 
 	ppJSON(out)
 	return nil
 }
 
-func jobGet(c *manager.Client, job string) error {
+func globalsGet(c *manager.Client, noop string, flags parsedFlags) error {
+	out, err := c.GetGlobals()
+	if err != nil {
+		return err
+	}
+
+	if !flags.jsonOutput {
+		return printTemplate(out, globalTemplate, &globalInfo{})
+	}
+
+	ppJSON(out)
+	return nil
+}
+
+func jobGet(c *manager.Client, job string, flags parsedFlags) error {
 	if job == "" {
 		return errUnexpectedArgCount("1", 0)
 	}
@@ -78,6 +212,10 @@ func jobGet(c *manager.Client, job string) error {
 	out, err := c.GetJob(job)
 	if err != nil {
 		return err
+	}
+
+	if !flags.jsonOutput {
+		return printTemplate(out, jobTemplate, &jobInfo{})
 	}
 
 	ppJSON(out)

--- a/management/src/clusterctl/post_actions.go
+++ b/management/src/clusterctl/post_actions.go
@@ -10,11 +10,6 @@ import (
 type postCallback func(c *manager.Client, args []string, flags parsedFlags) error
 type validateCallback func(args []string) error
 
-type parsedFlags struct {
-	extraVars string
-	hostGroup string
-}
-
 type postActioner struct {
 	args       []string
 	flags      parsedFlags

--- a/management/src/systemtests/clusterctl_test.go
+++ b/management/src/systemtests/clusterctl_test.go
@@ -13,7 +13,7 @@ func (s *SystemTestSuite) TestSetGetGlobalExtraVarsSuccess(c *C) {
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 
-	cmdStr = fmt.Sprintf(`clusterctl global get`)
+	cmdStr = fmt.Sprintf(`clusterctl global get --json`)
 	out, err = s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 	exptdOut := `.*"foo":.*"bar".*`
@@ -37,7 +37,7 @@ func (s *SystemTestSuite) TestGetNodeInfoSuccess(c *C) {
 }
 
 func (s *SystemTestSuite) TestGetNodesInfoSuccess(c *C) {
-	cmdStr := `clusterctl nodes get`
+	cmdStr := `clusterctl nodes get --json`
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 	exptdOut := `.*"monitoring_state":.*`

--- a/management/src/systemtests/utils.go
+++ b/management/src/systemtests/utils.go
@@ -86,7 +86,7 @@ func (s *SystemTestSuite) nukeNodesInInventory(c *C) {
 func (s *SystemTestSuite) checkProvisionStatus(c *C, tbn1 vagrantssh.TestbedNode, nodeName, exptdStatus string) {
 	exptdStr := fmt.Sprintf(`.*"status".*"%s".*`, exptdStatus)
 	out, err := tutils.WaitForDone(func() (string, bool) {
-		cmdStr := fmt.Sprintf("clusterctl node get %s", nodeName)
+		cmdStr := fmt.Sprintf("clusterctl node get %s --json", nodeName)
 		out, err := tbn1.RunCommandWithOutput(cmdStr)
 		if err != nil {
 			return out, false
@@ -102,7 +102,7 @@ func (s *SystemTestSuite) checkProvisionStatus(c *C, tbn1 vagrantssh.TestbedNode
 
 func (s *SystemTestSuite) checkHostGroup(c *C, nodeName, exptdGroup string) {
 	exptdStr := fmt.Sprintf(`.*"host_group".*"%s".*`, exptdGroup)
-	cmdStr := fmt.Sprintf("clusterctl node get %s", nodeName)
+	cmdStr := fmt.Sprintf("clusterctl node get %s --json", nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 	//replace newline with empty string for regex to match properly
@@ -211,7 +211,7 @@ func (s *SystemTestSuite) getNodeInfoFailureNonExistentNode(c *C, nodeName strin
 }
 
 func (s *SystemTestSuite) getNodeInfoSuccess(c *C, nodeName string) {
-	cmdStr := fmt.Sprintf(`clusterctl node get %s`, nodeName)
+	cmdStr := fmt.Sprintf(`clusterctl node get %s --json`, nodeName)
 	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
 	s.Assert(c, err, IsNil, Commentf("output: %s", out))
 	exptdOut := `.*"monitoring_state":.*`


### PR DESCRIPTION
fixes #116 

- the default output of `clusterctl <> get` commands will now be template based
- user can print the json output using `--json` flag
- the node info output is prefixed by node-name to make it easy to grep value of a particular field for a node

Sample outputs:
```

[vagrant@cluster-node1 ~]$ clusterctl global get
extra_vars:
    control_interface: eth1
    docker_version: 1.10.3
    env:
        HTTPS_PROXY: http://proxy.esl.cisco.com:8080
        HTTP_PROXY: http://proxy.esl.cisco.com:8080
        NO_PROXY:
        http_proxy: http://proxy.esl.cisco.com:8080
        https_proxy: http://proxy.esl.cisco.com:8080
        no_proxy:
    netplugin_if: eth2
    scheduler_provider: ucp-swarm
    service_vip: 192.168.2.252
    ucp_bootstrap_node_name: cluster-node1-0
    ucp_version: 1.1.0
    validate_certs: false

[vagrant@cluster-node1 ~]$ clusterctl node get cluster-node2-0
cluster-node2-0: Inventory State
cluster-node2-0:    name: cluster-node2-0
cluster-node2-0:    prev_state: Discovered
cluster-node2-0:    prev_status: Cancelled
cluster-node2-0:    state: Discovered
cluster-node2-0:    status: Decommissioned
cluster-node2-0: Monitoring State
cluster-node2-0:    label: cluster-node2
cluster-node2-0:    management_address: 192.168.2.11
cluster-node2-0:    serial_number: 0
cluster-node2-0: Configuration State
cluster-node2-0:    host_group: service-master
cluster-node2-0:    inventory_name: cluster-node2-0
cluster-node2-0:    inventory_vars:
cluster-node2-0:        etcd_master_addr:
cluster-node2-0:        etcd_master_name:
cluster-node2-0:        node_addr: 192.168.2.11
cluster-node2-0:        node_name: cluster-node2-0
cluster-node2-0:    ssh_address: 192.168.2.11

[vagrant@cluster-node1 ~]$ clusterctl job get last                                                                                                                                 [275/1830]

Description: decommissionEvent: nodes:[cluster-node1-0 cluster-node2-0] extra-vars: {}
Status: Complete
Error:
Logs:
    [DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and
    make sure become_method is 'sudo' (default).
    This feature will be removed in a
    future release. Deprecation warnings can be disabled by setting
    deprecation_warnings=False in ansible.cfg.

    PLAY [all] *********************************************************************

    TASK [setup] *******************************************************************
    ok: [cluster-node2-0]
    ok: [cluster-node1-0]

    TASK [include_vars] ************************************************************
    ok: [cluster-node1-0] => (item=contiv_network)
    ok: [cluster-node2-0] => (item=contiv_network)
    ok: [cluster-node1-0] => (item=contiv_storage)
    ok: [cluster-node2-0] => (item=contiv_storage)
...
...

```

/cc @vvb 
