### PR TITLE
reset active job in case of err

### DIFF
--- a/management/src/clusterm/manager/discover_event.go
+++ b/management/src/clusterm/manager/discover_event.go
@@ -61,7 +61,8 @@ func (e *discoverEvent) process() error {
 		}
 	}
 	if len(existingNodes) > 0 {
-		return errored.Errorf("one or more nodes already exist with the specified management addresses. Existing nodes: %v", existingNodes)
+		err = errored.Errorf("one or more nodes already exist with the specified management addresses. Existing nodes: %v", existingNodes)
+		return err
 	}
 
 	// prepare inventory


### PR DESCRIPTION
* We were just returning error, without clearing the job in the queue.
* We already have a deferred function that is suppose to clean up the activejob in case of an error, but it relies on variable `err` being set.