### PR TITLE
fix make demo-cluster to not install serf

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -147,11 +147,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 end
             end
 
-            # provision base packages needed for cluster management
-            if ansible_groups["cluster-node"] == nil then
-                ansible_groups["cluster-node"] = [ ]
+            # in dev mode, provision base packages needed for cluster management
+            # by tests
+            if clusterm_dev then
+                if ansible_groups["cluster-node"] == nil then
+                    ansible_groups["cluster-node"] = [ ]
+                end
+                ansible_groups["cluster-node"] << node_name
             end
-            ansible_groups["cluster-node"] << node_name
 
             # The first vm stimulates the first manually **configured** nodes
             # in a cluster

--- a/management/README.md
+++ b/management/README.md
@@ -31,6 +31,19 @@ CONTIV_NODES=3 make demo-cluster
 CONTIV_NODES=3 vagrant ssh cluster-node1
 ```
 
+#### Provision additional nodes for discovery
+```
+clusterctl discover <host-ip(s)>
+```
+Cluster Manager uses Serf as a discovery service for node health monitoring and for cluster bootstrapping. Use `discover` command to include additional nodes in the discovery service. The `<host-ip>` should be an IP address from a management network only used by infra services such as serf, etcd, swarm, etc..
+
+**Note**:
+```
+clusterctl discover 192.168.2.11 192.168.2.12 --extra-vars='{"env" : {}, "control_interface": "eth1" }'
+```
+- The command above will provision the other two vms (viz. cluster-node2 and cluster-node3) in the vagrant setup for serf based discovery. Once it is run, the discovered hosts will appear in `clusterctl nodes get` output in a few minutes.
+- the `clusterctl discover` command expects `env` and `control_interface` ansible variables to be specified. This can be achieved by using the `--extra-vars` flag as shown above or by setting them at [global level](#setget-global-variables), if applicable. For more information on other available variables, also checkout [discovery section of ansible vars](ansible_vars.md#serf-based-discovery)
+
 #### Get list of discovered nodes
 ```
 clusterctl nodes get
@@ -48,7 +61,7 @@ Commissioning a node involves pushing the configuration and starting infra servi
 **Note**:
 - certain ansible variables need to be set for provisioning a node. The list of mandatory and other useful variables is provided in [ansible_vars.md](./ansible_vars.md). The variables need to be passed as a quoted JSON string in node commission command using the `--extra-vars` flag.
 ```
-clusterctl node commission node1 --extra-vars='{"env" : {"http_proxy": "my.proxy.url"}, "control_interface": "eth2", "netplugin_if": "eth1" }' --host-group "service-master"
+clusterctl node commission node1 --extra-vars='{"env" : {}, "control_interface": "eth1", "netplugin_if": "eth2" }' --host-group "service-master"
 ```
 - a common set of variables (like environment) can be set just once as [global variables](#setget-global-variables). This eliminates the need to specify the common variables for every commission command.
 

--- a/management/ansible_vars.md
+++ b/management/ansible_vars.md
@@ -18,7 +18,7 @@ There are several variables that are made available to provide a good level of p
 - **env** is used to set the environment variables that need to be available to ansible tasks. A common usecase of this variable is to set the http-proxy info.
   - **env** is specified as a JSON dictionary. 
   ```
-  {"env": { "var1": "val1"}}
+  {"env": { "var1": "val1", "http_proxy": "http://my.proxy.url", "https_proxy": "http://my.proxy.url" }}
   ```
   - It should be set to empty dictionary if no environment variables needs to be set.
   ```

--- a/management/baremetal.md
+++ b/management/baremetal.md
@@ -52,18 +52,5 @@ After the changes look good, restart cluster manager
 sudo systemctl restart clusterm
 ```
 
-###3. Provision additional nodes for discovery
-Cluster Manager uses Serf as a discovery service for node health monitoring and for cluster bootstrapping.
-Use ```clusterctl discover``` to include additional nodes in the discovery service.
-The `<host-ip>` should be an IP address from a management network only used by infra services
-such as serf, etcd, swarm, etc..
-```
-clusterctl discover <host-ip>
-```
-
-**Note**:
-- Once the above command is run for a host, it will appear in `clusterctl nodes get` output in a few minutes.
-- the `clusterctl discover` command expects `env` and `control_interface` ansible variables to be specified. This can be achieved by using the `--extra-vars` flag or setting them at [global level](README.md/#setget-global-variables), if applicable. For more information on other available variables, also checkout [discovery section of ansible vars](ansible_vars.md#serf-based-discovery)
-
-###4. Ready to rock and roll!
-All set now, you can follow the cluster manager workflows as described [here](./README.md#get-list-of-discovered-nodes).
+###3. Ready to rock and roll!
+All set now, you can follow the cluster manager workflows as described [here](./README.md#provision-additional-nodes-for-discovery).


### PR DESCRIPTION
this allows running end to end cluster workflows in the vagrant demo (similar to baremetal environment).

Also updated the documentation to consolidate the steps in README.md.

/cc @vishal-j . This is per our discussion in the morning.