### PR TITLE
 remove the code for setting up etcd specific variables in clusterm and demo environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,8 +102,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         node_name = node_names[n]
         node_addr = node_ips[n]
         node_vars = {
-            "etcd_master_addr" => node_ips[0],
-            "etcd_master_name" => node_names[0],
             "ucp_bootstrap_node_name" => node_names[0],
         }
         config.vm.define node_name do |node|
@@ -215,15 +213,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 node.vm.provision 'bootstrap-ansible', type: 'ansible' do |ansible|
                     ansible.groups = bootstrap_node_ansible_groups
                     ansible.playbook = ansible_playbook
-                    ansible.extra_vars = ansible_extra_vars.clone
+                    ansible.extra_vars = ansible_extra_vars
                     ansible.limit = 'all'
                 end
+                # 'main-ansible' provisioner helps us test etcd member addition
+                # scenario in the demo environment
                 node.vm.provision 'main-ansible', type: 'ansible' do |ansible|
                     ansible.groups = ansible_groups
                     ansible.playbook = ansible_playbook
-                    ansible.extra_vars = ansible_extra_vars.clone
-                    # Turn off init cluster as this is a member-add scenario
-                    ansible.extra_vars["etcd_init_cluster"] = false
+                    ansible.extra_vars = ansible_extra_vars
                     ansible.limit = 'all'
                 end
                 # run the shell provisioner on the first node, after all the provisioners,

--- a/management/src/clusterm/manager/commission_event.go
+++ b/management/src/clusterm/manager/commission_event.go
@@ -104,10 +104,8 @@ func (e *commissionEvent) eventValidate() error {
 // of the existing master nodes.
 func (e *commissionEvent) prepareInventory() error {
 	nodeGroup := e.hostGroup
-	masterAddr := ""
-	masterName := ""
 	masterCommissioned := false
-	for name, node := range e.mgr.nodes {
+	for name := range e.mgr.nodes {
 		if _, ok := e._enodes[name]; ok {
 			// skip nodes in the event
 			continue
@@ -132,9 +130,6 @@ func (e *commissionEvent) prepareInventory() error {
 		}
 
 		// found a master node
-		masterAddr = node.Mon.GetMgmtAddress()
-		masterName = node.Cfg.GetTag()
-
 		masterCommissioned = true
 		break
 	}
@@ -148,8 +143,6 @@ func (e *commissionEvent) prepareInventory() error {
 	for _, node := range e._enodes {
 		hostInfo := node.Cfg.(*configuration.AnsibleHost)
 		hostInfo.SetGroup(nodeGroup)
-		hostInfo.SetVar(ansibleEtcdMasterAddrHostVar, masterAddr)
-		hostInfo.SetVar(ansibleEtcdMasterNameHostVar, masterName)
 		hosts = append(hosts, hostInfo)
 	}
 	e._hosts = hosts

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -63,13 +63,11 @@ const (
 )
 
 const (
-	ansibleMasterGroupName       = "service-master"
-	ansibleWorkerGroupName       = "service-worker"
-	ansibleDiscoverGroupName     = "cluster-node"
-	ansibleNodeNameHostVar       = "node_name"
-	ansibleNodeAddrHostVar       = "node_addr"
-	ansibleEtcdMasterAddrHostVar = "etcd_master_addr"
-	ansibleEtcdMasterNameHostVar = "etcd_master_name"
+	ansibleMasterGroupName   = "service-master"
+	ansibleWorkerGroupName   = "service-worker"
+	ansibleDiscoverGroupName = "cluster-node"
+	ansibleNodeNameHostVar   = "node_name"
+	ansibleNodeAddrHostVar   = "node_addr"
 
 	jobLabelActive = "active"
 	jobLabelLast   = "last"

--- a/vendor/ansible/roles/docker/tasks/main.yml
+++ b/vendor/ansible/roles/docker/tasks/main.yml
@@ -131,6 +131,7 @@
     url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-{{ ansible_system }}-{{ ansible_userspace_architecture }}
     dest: /usr/bin/docker-compose
     mode: u=rwx,g=rx,o=rx
+    force: yes
   when: not (docker_compose_installed_version.stdout | match('docker-compose version {{ docker_compose_version }},.*'))
   tags:
     - prebake-for-dev

--- a/vendor/ansible/roles/etcd/defaults/main.yml
+++ b/vendor/ansible/roles/etcd/defaults/main.yml
@@ -6,14 +6,7 @@ etcd_client_port2: 4001
 etcd_peer_port1: 2380
 etcd_peer_port2: 7001
 etcd_peers_group: "service-master"
-etcd_init_cluster: true
 etcd_rule_comment: "etcd traffic"
 etcd_version: "v2.3.1"
 etcd_heartbeat_interval: 1000
 etcd_election_timeout: 10000
-
-# following variables are used in one or more roles, but have no good default value to pick from.
-# Leaving them as commented so that playbooks can fail early with variable not defined error.
-
-#etcd_master_addr:
-#etcd_master_name:

--- a/vendor/ansible/roles/etcd/tasks/main.yml
+++ b/vendor/ansible/roles/etcd/tasks/main.yml
@@ -32,10 +32,8 @@
     - "{{ etcd_peer_port1 }}"
     - "{{ etcd_peer_port2 }}"
 
-# The second part of the condition avoids reconfiguring master if it was already present in the host-group
 - name: copy the etcd start/stop script
   template: src=etcd.j2 dest=/usr/bin/etcd.sh mode=u=rwx,g=rx,o=rx
-  when: (etcd_init_cluster == true) or (etcd_init_cluster == false and node_addr != etcd_master_addr)
 
 - name: copy systemd units for etcd
   copy: src=etcd.service dest=/etc/systemd/system/etcd.service

--- a/vendor/ansible/roles/etcd/templates/etcd.j2
+++ b/vendor/ansible/roles/etcd/templates/etcd.j2
@@ -51,7 +51,7 @@ export ETCD_INITIAL_CLUSTER_TOKEN=contiv-cluster
 export ETCD_LISTEN_CLIENT_URLS={{ client_url("0.0.0.0") }}
 export ETCD_ADVERTISE_CLIENT_URLS={{ client_url(node_addr) }}
 export ETCD_INITIAL_ADVERTISE_PEER_URLS={{ peer_url(node_addr) }}
-export ETCD_LISTEN_PEER_URLS=http://{{ node_addr }}:{{ etcd_peer_port1 }}
+export ETCD_LISTEN_PEER_URLS=http://0.0.0.0:{{ etcd_peer_port1 }}
 export ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}
 export ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 
@@ -62,7 +62,7 @@ export ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 #  - address of that peer node
 add_proxy() {
     export ETCD_PROXY=on
-    export ETCD_INITIAL_CLUSTER="{{ cluster_url("${1}", "${2}") }}"
+    export ETCD_INITIAL_CLUSTER="{{ cluster_url('cluster_vip', service_vip) }}"
 }
 {% else %}
 # get_peers() returns a comma separated list of peers in 'peers' variable
@@ -127,7 +127,7 @@ add_member() {
 # Else it adds the node to exisitng cluster
 # @args:
 # - none
-init_cluster() {
+init_update_cluster() {
     # on master nodes, if the cluster is being initialized for first time then initialize it
     peers=""
     get_peers "{{ get_peer_addr() }}"
@@ -164,12 +164,9 @@ start)
     fi
     {% if run_as == "worker" -%}
     # on worker nodes, run etcd in proxy mode
-    add_proxy "{{ etcd_master_name }}" "{{ etcd_master_addr }}"
-    {% elif etcd_init_cluster -%}
-    init_cluster
+    add_proxy
     {% else -%}
-    # if a new master node is being commissioned then add it to existing cluster
-    add_member "{{ etcd_master_addr }}"
+    init_update_cluster
     {% endif -%}
 
     #start etcd


### PR DESCRIPTION
- this makes cluster-mgr agnostic of specific services that are brought up by ansible
- also vendored new ansible to pull in simplified etcd scripts (https://github.com/contiv/ansible/pull/237), which is required for this change to work for demo environments.