### PR TITLE
Remove the endpoint for single node operations

### DIFF
--- a/management/src/clusterm/manager/api.go
+++ b/management/src/clusterm/manager/api.go
@@ -77,11 +77,8 @@ func (m *Manager) apiLoop(errCh chan error, servingCh chan struct{}) {
 			{"/" + getJob, emptyHdrs, get(m.jobGet)},
 		},
 		"POST": {
-			{"/" + postNodeCommission, jsonContentHdrs, post(m.nodesCommission)},
 			{"/" + PostNodesCommission, jsonContentHdrs, post(m.nodesCommission)},
-			{"/" + postNodeDecommission, jsonContentHdrs, post(m.nodesDecommission)},
 			{"/" + PostNodesDecommission, jsonContentHdrs, post(m.nodesDecommission)},
-			{"/" + postNodeUpdate, jsonContentHdrs, post(m.nodesUpdate)},
 			{"/" + PostNodesUpdate, jsonContentHdrs, post(m.nodesUpdate)},
 			{"/" + PostNodesDiscover, jsonContentHdrs, post(m.nodesDiscover)},
 			{"/" + PostGlobals, jsonContentHdrs, post(m.globalsSet)},

--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -87,10 +87,11 @@ func (c *Client) doGet(rsrc string) ([]byte, error) {
 // PostNodeCommission posts the request to commission a node
 func (c *Client) PostNodeCommission(nodeName, extraVars, hostGroup string) error {
 	req := &APIRequest{
+		Nodes:     []string{nodeName},
 		HostGroup: hostGroup,
 		ExtraVars: extraVars,
 	}
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeCommissionPrefix, nodeName), req)
+	return c.doPost(PostNodesCommission, req)
 }
 
 // PostNodesCommission posts the request to commission a set of nodes
@@ -106,9 +107,10 @@ func (c *Client) PostNodesCommission(nodeNames []string, extraVars, hostGroup st
 // PostNodeDecommission posts the request to decommission a node
 func (c *Client) PostNodeDecommission(nodeName, extraVars string) error {
 	req := &APIRequest{
+		Nodes:     []string{nodeName},
 		ExtraVars: extraVars,
 	}
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeDecommissionPrefix, nodeName), req)
+	return c.doPost(PostNodesDecommission, req)
 }
 
 // PostNodesDecommission posts the request to decommission a set of nodes
@@ -124,10 +126,11 @@ func (c *Client) PostNodesDecommission(nodeNames []string, extraVars string) err
 // it's host-group when it is specified.
 func (c *Client) PostNodeUpdate(nodeName, extraVars, hostGroup string) error {
 	req := &APIRequest{
+		Nodes:     []string{nodeName},
 		ExtraVars: extraVars,
 		HostGroup: hostGroup,
 	}
-	return c.doPost(fmt.Sprintf("%s/%s", PostNodeUpdatePrefix, nodeName), req)
+	return c.doPost(PostNodesUpdate, req)
 }
 
 // PostNodesUpdate posts the request to update a set of node and optionally change

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -3,28 +3,13 @@
 package manager
 
 const (
-	// PostNodeCommissionPrefix is the prefix for the POST REST endpoint
-	// to commission an asset
-	PostNodeCommissionPrefix = "commission/node"
-	postNodeCommission       = PostNodeCommissionPrefix + "/{tag}"
-
 	// PostNodesCommission is the prefix for the POST REST endpoint
 	// to commission one or more assets
 	PostNodesCommission = "commission/nodes"
 
-	// PostNodeDecommissionPrefix is the prefix for the POST REST endpoint
-	// to decommission an asset
-	PostNodeDecommissionPrefix = "decommission/node"
-	postNodeDecommission       = PostNodeDecommissionPrefix + "/{tag}"
-
 	// PostNodesDecommission is the prefix for the POST REST endpoint
 	// to decommission one or more assets
 	PostNodesDecommission = "decommission/nodes"
-
-	// PostNodeUpdatePrefix is the prefix for the POST REST endpoint
-	// to update configuration of an asset
-	PostNodeUpdatePrefix = "update/node"
-	postNodeUpdate       = PostNodeUpdatePrefix + "/{tag}"
 
 	// PostNodesUpdate is the prefix for the POST REST endpoint
 	// to update configuration of one or more assets


### PR DESCRIPTION
the single node behavior can be achieved by the 'nodes' endpoint.

Also updated the client package to use the 'nodes' endpoint for single node operations.

fixes #164 

/cc @vvb , also @vishal-j just fyi as this might affect the GUI