### PR TITLE
Vagrantfile: change box version and subnet ip

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 gopath_dir="/opt/gopath"
 gobin_dir="#{gopath_dir}/bin"
-base_ip = "192.168.2."
+base_ip = "172.16.2."
 
 num_nodes = 1
 if ENV['CONTIV_NODES'] && ENV['CONTIV_NODES'] != "" then
@@ -27,7 +27,7 @@ if ENV['CONTIV_BOX'] then
     box = ENV['CONTIV_BOX']
 end
 
-box_version = "0.6.0"
+box_version = "0.7.0"
 if ENV['CONTIV_BOX_VERSION'] then
     box_version = ENV['CONTIV_BOX_VERSION']
 end

--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -109,7 +109,7 @@ system-test:
 	 export CONTIV_SOE=${CONTIV_SOE}; \
 	 export GOPATH=/opt/gopath/; \
 	 export PATH=\$$PATH:\$$GOPATH/bin; \
-	 export CONTIV_NODE_IPS='192.168.2.10,192.168.2.11'; \
+	 export CONTIV_NODE_IPS='172.16.2.10,172.16.2.11'; \
 	 if [ \"${http_proxy}\" != \"\" ]; then export http_proxy=${http_proxy}; fi; \
 	 if [ \"${https_proxy}\" != \"\" ]; then export https_proxy=${https_proxy}; fi; \
 	 cd \$$GOPATH/src/github.com/contiv/cluster/management/src; \


### PR DESCRIPTION
- bumped up the box version
- changed subnet ip range to not collide with volplugin, this is a interim fix until we get the random subnet
  generation logic similar to volplugin. For now, this will allow volplugin and cluster CI to run in parallel.