### PR TITLE
add API endpoint and CLI to get and set clusterm config

### DIFF
--- a/management/src/Makefile
+++ b/management/src/Makefile
@@ -103,7 +103,7 @@ host-system-test: checks
 
 system-test:
 	@echo "running system-tests"
-	CONTIV_NODES=2 time vagrant up; \
+	CONTIV_NODES=2 time vagrant up
 	time vagrant ssh cluster-node1 -c \
 	"set -e; \
 	 export CONTIV_SOE=${CONTIV_SOE}; \

--- a/management/src/clusterctl/commands.go
+++ b/management/src/clusterctl/commands.go
@@ -55,21 +55,21 @@ var (
 					Name:    "commission",
 					Aliases: []string{"c"},
 					Usage:   "commission a node",
-					Action:  doAction(newPostActioner(validateOneNodeName, nodeCommission)),
+					Action:  doAction(newPostActioner(validateOneArg, nodeCommission)),
 					Flags:   postHostGroupFlags,
 				},
 				{
 					Name:    "decommission",
 					Aliases: []string{"d"},
 					Usage:   "decommission a node",
-					Action:  doAction(newPostActioner(validateOneNodeName, nodeDecommission)),
+					Action:  doAction(newPostActioner(validateOneArg, nodeDecommission)),
 					Flags:   postFlags,
 				},
 				{
 					Name:    "update",
 					Aliases: []string{"u"},
 					Usage:   "update a node",
-					Action:  doAction(newPostActioner(validateOneNodeName, nodeUpdate)),
+					Action:  doAction(newPostActioner(validateOneArg, nodeUpdate)),
 					Flags:   postHostGroupFlags,
 				},
 				{
@@ -157,6 +157,26 @@ var (
 			Usage:   "provision one or more nodes for discovery",
 			Action:  doAction(newPostActioner(validateMultiNodeAddrs, nodesDiscover)),
 			Flags:   postFlags,
+		},
+		{
+			Name:    "config",
+			Aliases: []string{"c"},
+			Usage:   "set/get clusterm configuration",
+			Subcommands: []cli.Command{
+				{
+					Name:    "get",
+					Aliases: []string{"g"},
+					Usage:   "get clusterm configuration",
+					Action:  doAction(newGetActioner(configGet)),
+					Flags:   getFlags,
+				},
+				{
+					Name:    "set",
+					Aliases: []string{"s"},
+					Usage:   "set clusterm configuration. use '-' as the arg to read JSON configuration from stdin, else provide a path to the file containing JSON configuration",
+					Action:  doAction(newPostActioner(validateOneArg, configSet)),
+				},
+			},
 		},
 	}
 )

--- a/management/src/clusterctl/get_actions.go
+++ b/management/src/clusterctl/get_actions.go
@@ -23,6 +23,8 @@ type jobInfo map[string]interface{}
 
 type globalInfo map[string]interface{}
 
+type configInfo map[string]interface{}
+
 // printHelper stores indent related metadat along with the value being printed
 type printHelper struct {
 	Indent string
@@ -89,6 +91,9 @@ var (
 
 	globalPrint    = `{{ template "typePrint" newPrintHelper "" .}}`
 	globalTemplate = template.Must(template.Must(typeTemplate.Clone()).Parse(globalPrint))
+
+	configPrint    = `{{ template "typePrint" newPrintHelper "" .}}`
+	configTemplate = template.Must(template.Must(typeTemplate.Clone()).Parse(configPrint))
 
 	nodePrint = `
 {{- define "nodePrint" }}
@@ -216,6 +221,20 @@ func jobGet(c *manager.Client, job string, flags parsedFlags) error {
 
 	if !flags.jsonOutput {
 		return printTemplate(out, jobTemplate, &jobInfo{})
+	}
+
+	ppJSON(out)
+	return nil
+}
+
+func configGet(c *manager.Client, noop string, flags parsedFlags) error {
+	out, err := c.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if !flags.jsonOutput {
+		return printTemplate(out, configTemplate, &configInfo{})
 	}
 
 	ppJSON(out)

--- a/management/src/clusterctl/main_test.go
+++ b/management/src/clusterctl/main_test.go
@@ -23,7 +23,7 @@ func (s *mainSuite) TestCommandArgValidationError(c *C) {
 		exptdErr error
 	}{
 		"one-node-name": {
-			f:        validateOneNodeName,
+			f:        validateOneArg,
 			args:     []string{"", ""},
 			exptdErr: errUnexpectedArgCount("1", len([]string{"", ""})),
 		},

--- a/management/src/clusterm/main.go
+++ b/management/src/clusterm/main.go
@@ -71,6 +71,7 @@ func getConfig(c *cli.Context) (*manager.Config, error) {
 		if err != nil {
 			return nil, errored.Errorf("failed to open config file. Error: %v", err)
 		}
+		defer func() { f.Close() }()
 		log.Debugf("reading configuration from file: %q", c.GlobalString("config"))
 		reader = bufio.NewReader(f)
 	}

--- a/management/src/clusterm/manager/api_test.go
+++ b/management/src/clusterm/manager/api_test.go
@@ -35,6 +35,13 @@ func (s *apiSuite) TestPostHandlerErrorCase(c *C) {
 			},
 			exptdErr: errInvalidEventName(""),
 		},
+		"config-event-nil-config": {
+			cb: m.configSet,
+			arg: &APIRequest{
+				Config: nil,
+			},
+			exptdErr: errNilConfig(),
+		},
 	}
 
 	for key, test := range tests {

--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -172,6 +172,14 @@ func (c *Client) PostMonitorEvent(event string, nodes []MonitorNode) error {
 	return c.doPost(PostMonitorEvent, req)
 }
 
+// PostConfig posts the request to set clusterm configuration
+func (c *Client) PostConfig(config *Config) error {
+	req := &APIRequest{
+		Config: config,
+	}
+	return c.doPost(GetPostConfig, req)
+}
+
 // GetNode requests info of a specified node
 func (c *Client) GetNode(nodeName string) ([]byte, error) {
 	return c.doGet(fmt.Sprintf("%s/%s", GetNodeInfoPrefix, nodeName))
@@ -185,6 +193,11 @@ func (c *Client) GetAllNodes() ([]byte, error) {
 // GetGlobals requests the value global extra vars
 func (c *Client) GetGlobals() ([]byte, error) {
 	return c.doGet(GetGlobals)
+}
+
+// GetConfig requests the value of current clusterm configuration
+func (c *Client) GetConfig() ([]byte, error) {
+	return c.doGet(GetPostConfig)
 }
 
 // GetJob requests the info of a provisioning job specified by jobLabel.

--- a/management/src/clusterm/manager/config.go
+++ b/management/src/clusterm/manager/config.go
@@ -59,11 +59,11 @@ func DefaultConfig() *Config {
 func (c *Config) Read(r io.Reader) error {
 	bytes, err := ioutil.ReadAll(r)
 	if err != nil {
-		return err
+		return errored.Errorf("failed to read config. Error: %v", err)
 	}
 
 	if err := json.Unmarshal(bytes, c); err != nil {
-		return err
+		return errInvalidJSON("config", err)
 	}
 
 	return nil

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -45,6 +45,10 @@ const (
 	// 'active' or 'last'
 	GetJobPrefix = "info/job"
 	getJob       = GetJobPrefix + "/{job}"
+
+	// GetPostConfig is the prefix for the REST endpoint
+	// to GET current or POST updated clusterm's configuration
+	GetPostConfig = "config"
 )
 
 const (

--- a/management/src/clusterm/manager/set_config_event.go
+++ b/management/src/clusterm/manager/set_config_event.go
@@ -1,0 +1,92 @@
+package manager
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/contiv/errored"
+)
+
+func configChangeNotPermittedError(config string) error {
+	return errored.Errorf("%q configuration can't be changed. Only changes to ansible configuration are allowed.", config)
+}
+
+// setConfigEvent triggers the update to global configuration
+type setConfigEvent struct {
+	mgr    *Manager
+	config *Config
+}
+
+// newSetConfigEvent creates and returns setConfigEvent
+func newSetConfigEvent(mgr *Manager, config *Config) *setConfigEvent {
+	return &setConfigEvent{
+		mgr:    mgr,
+		config: config,
+	}
+}
+
+func (e *setConfigEvent) String() string {
+	return fmt.Sprintf("setConfigEvent: %+v", e.config)
+}
+
+func (e *setConfigEvent) process() error {
+	// err shouldn't be redefined below
+	var err error
+
+	// we set a noop job to ensure that even for the short time this event is
+	// run no other job get's enqueued and catches us in middle of things
+	err = e.mgr.checkAndSetActiveJob(
+		e.String(),
+		e.noopRunner,
+		func(status JobStatus, errRet error) { return })
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			e.mgr.resetActiveJob()
+		}
+	}()
+
+	// merge the config with default and validate
+	finalConfig := DefaultConfig()
+	err = finalConfig.Merge(e.config)
+	if err != nil {
+		return err
+	}
+	e.config = finalConfig
+	err = e.eventValidate()
+	if err != nil {
+		return err
+	}
+
+	// update manager's config
+	e.mgr.config = e.config
+
+	// trigger the noop job
+	go e.mgr.runActiveJob()
+
+	return nil
+}
+
+func (e *setConfigEvent) eventValidate() error {
+	// make sure we are only changing ansible related config.
+	// Changes to monitoring, inventory and manager config is not supported
+
+	if !reflect.DeepEqual(e.config.Serf, e.mgr.config.Serf) {
+		return configChangeNotPermittedError("serf")
+	}
+	if !reflect.DeepEqual(e.config.Inventory, e.mgr.config.Inventory) {
+		return configChangeNotPermittedError("inventory")
+	}
+	if !reflect.DeepEqual(e.config.Manager, e.mgr.config.Manager) {
+		return configChangeNotPermittedError("manager")
+	}
+
+	return nil
+}
+
+func (e *setConfigEvent) noopRunner(cancelCh CancelChannel, jobLogs io.Writer) error {
+	return nil
+}

--- a/management/src/monitor/serf.go
+++ b/management/src/monitor/serf.go
@@ -27,8 +27,10 @@ type SerfSubsys struct {
 
 // NewSerfSubsys initializes and return a SerfSubsys instance
 func NewSerfSubsys(config *client.Config) *SerfSubsys {
+	//XXX: make a copy of the config as the serf client changes the config
+	c := *config
 	sm := &SerfSubsys{
-		config: config,
+		config: &c,
 		router: serfer.NewRouter(),
 	}
 	return sm

--- a/management/src/systemtests/clusterctl_test.go
+++ b/management/src/systemtests/clusterctl_test.go
@@ -3,7 +3,10 @@
 package systemtests
 
 import (
+	"encoding/json"
 	"fmt"
+
+	"github.com/imdario/mergo"
 
 	. "gopkg.in/check.v1"
 )
@@ -46,4 +49,58 @@ func (s *SystemTestSuite) TestGetNodesInfoSuccess(c *C) {
 	s.assertMultiMatch(c, exptdOut, out, 2)
 	exptdOut = `.*"configuration_state".*`
 	s.assertMultiMatch(c, exptdOut, out, 2)
+}
+
+func (s *SystemTestSuite) TestSetGetConfigSuccess(c *C) {
+	// read current config, to prepare the test config with just ansible changes
+	cmdStr := `clusterctl config get --json`
+	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
+	s.Assert(c, err, IsNil, Commentf("output: %s", out))
+	var config map[string]interface{}
+	err = json.Unmarshal([]byte(out), &config)
+	s.Assert(c, err, IsNil)
+	var testConfig map[string]interface{}
+	err = json.Unmarshal([]byte(`{
+    "ansible": {
+        "playbook_location":  "foo"
+    }
+}`), &testConfig)
+	s.Assert(c, err, IsNil)
+	err = mergo.MergeWithOverwrite(&config, &testConfig)
+	s.Assert(c, err, IsNil)
+	configStr, err := json.Marshal(config)
+	s.Assert(c, err, IsNil)
+
+	c.Logf("config: %+v", config)
+	c.Logf("json: %q", configStr)
+	cmdStr = fmt.Sprintf(`clusterctl config set - <<EOF
+%s
+EOF`, configStr)
+	out, err = s.tbn1.RunCommandWithOutput(cmdStr)
+	s.Assert(c, err, IsNil, Commentf("output: %s", out))
+	cmdStr = `clusterctl config get --json`
+	out, err = s.tbn1.RunCommandWithOutput(cmdStr)
+	s.Assert(c, err, IsNil, Commentf("output: %s", out))
+	exptdOut := `.*"playbook_location":.*"foo".*`
+	s.assertMatch(c, exptdOut, out)
+}
+
+func (s *SystemTestSuite) TestSetGetConfigFailureNotPermitted(c *C) {
+	cmdStr := `clusterctl config set - <<EOF
+{
+    "ansible": {
+        "playbook_location":  "foo"
+    },
+    "inventory": {
+        "collins": {
+            "url": "foobar"
+        }
+    }
+}
+EOF
+`
+	out, err := s.tbn1.RunCommandWithOutput(cmdStr)
+	s.Assert(c, err, NotNil, Commentf("output: %s", out))
+	exptdOut := `.*Request URL: config.*Only changes to ansible configuration are allowed.*`
+	s.assertMatch(c, exptdOut, out)
 }


### PR DESCRIPTION
This is the second part of changes to address #176 . The next and last part will cover the signal handler and documentation updates.

- added /config GET/POST REST endpoint
- added the event handler for config set action
   - event handler registers a noop job to prevent any other action while config change is in progress
   - it merges the received config with defaults before validation and application. Merge helps user by not  requiring to specify any default config. Validation ensures that we are only allowing ansible configuration to change atm.
- added client methods for the configuration endpoint
- added cli to set/get clusterm configuration
- added systemtests for the config set/get endpoint
- improved config.Read() errors
- fixed a file handle leak by closing the file once configuration is read (on clusterm start up)
- fixed an inadvertent update to clusterm's in-memory copy of it's configuration that used to happen after initializng serf client which internally modifies the passed config instance
- minor enhancement to `make system-test` target to run `vagrant up` as separate command