### PR TITLE
Add SIGHUP handler to allow reloading configuration file

### DIFF
--- a/management/baremetal.md
+++ b/management/baremetal.md
@@ -47,9 +47,9 @@ Edit the cluster manager configuration file that is created at `/etc/default/clu
     }
 }
 ```
-After the changes look good, restart cluster manager
+After the changes look good, signal cluster manager to load the updated configuration
 ```
-sudo systemctl restart clusterm
+sudo systemctl kill -sHUP clusterm
 ```
 
 ###3. Ready to rock and roll!

--- a/management/src/clusterctl/post_actions.go
+++ b/management/src/clusterctl/post_actions.go
@@ -126,8 +126,8 @@ func configSet(c *manager.Client, args []string, noop parsedFlags) error {
 		reader = bufio.NewReader(f)
 	}
 
-	config := &manager.Config{}
-	if err := config.Read(reader); err != nil {
+	config, err := (&manager.Config{}).MergeFromReader(reader)
+	if err != nil {
 		return err
 	}
 

--- a/management/src/clusterm/main.go
+++ b/management/src/clusterm/main.go
@@ -61,7 +61,6 @@ func main() {
 func getConfig(c *cli.Context) (*manager.Config, string, error) {
 	var reader io.Reader
 	configFile := ""
-	config := manager.DefaultConfig()
 	if !c.GlobalIsSet("config") {
 		log.Debugf("no configuration was specified, starting with default.")
 	} else if c.GlobalString("config") == "-" {
@@ -77,12 +76,9 @@ func getConfig(c *cli.Context) (*manager.Config, string, error) {
 		reader = bufio.NewReader(f)
 		configFile = c.GlobalString("config")
 	}
+	config := manager.DefaultConfig()
 	if reader != nil {
-		uConfig := &manager.Config{}
-		if err := uConfig.Read(reader); err != nil {
-			return nil, "", errored.Errorf("failed to read configuration. Error: %v", err)
-		}
-		if err := config.Merge(uConfig); err != nil {
+		if _, err := config.MergeFromReader(reader); err != nil {
 			return nil, "", errored.Errorf("failed to merge configuration. Error: %v", err)
 		}
 	}

--- a/management/src/clusterm/manager/config_test.go
+++ b/management/src/clusterm/manager/config_test.go
@@ -23,7 +23,7 @@ func (s *configSuite) TestReadConfigSuccess(c *C) {
 			"playbook_location" : "foo"
 		}
 	}`
-	err := config.Read(strings.NewReader(confStr))
+	_, err := config.read(strings.NewReader(confStr))
 	c.Assert(err, IsNil)
 	c.Assert(config.Ansible.PlaybookLocation, Equals, "foo")
 }
@@ -35,7 +35,7 @@ func (s *configSuite) TestReadConfigInvalidJSON(c *C) {
 			"playbook_location" : "extra-comma-error",
 		}
 	}`
-	err := config.Read(strings.NewReader(confStr))
+	_, err := config.read(strings.NewReader(confStr))
 	c.Assert(err, NotNil)
 }
 
@@ -47,7 +47,7 @@ func (s *configSuite) TestMergeConfigSuccess(c *C) {
 	exptdDst := DefaultConfig()
 	exptdDst.Ansible.PlaybookLocation = "override-location"
 
-	err := dst.Merge(src)
+	_, err := dst.MergeFromConfig(src)
 	c.Assert(err, IsNil)
 	c.Assert(dst, DeepEquals, exptdDst)
 }
@@ -57,7 +57,7 @@ func (s *configSuite) TestMergeConfigSuccessNoInventory(c *C) {
 	src := &Config{}
 	exptdDst := DefaultConfig()
 
-	err := dst.Merge(src)
+	_, err := dst.MergeFromConfig(src)
 	c.Assert(err, IsNil)
 	c.Assert(dst, DeepEquals, exptdDst)
 	c.Assert(dst.Inventory.Collins, Equals, (*collins.Config)(nil))
@@ -72,7 +72,7 @@ func (s *configSuite) TestMergeConfigSuccessCollinsInventory(c *C) {
 	exptdDst := DefaultConfig()
 	exptdDst.Inventory.Collins = &collins.Config{}
 
-	err := dst.Merge(src)
+	_, err := dst.MergeFromConfig(src)
 	c.Assert(err, IsNil)
 	c.Assert(dst, DeepEquals, exptdDst)
 	c.Assert(dst.Inventory.BoltDB, Equals, (*boltdb.Config)(nil))
@@ -87,7 +87,7 @@ func (s *configSuite) TestMergeConfigSuccessBoltdbInventory(c *C) {
 	exptdDst := DefaultConfig()
 	exptdDst.Inventory.BoltDB = &boltdb.Config{}
 
-	err := dst.Merge(src)
+	_, err := dst.MergeFromConfig(src)
 	c.Assert(err, IsNil)
 	c.Assert(dst, DeepEquals, exptdDst)
 	c.Assert(dst.Inventory.BoltDB, DeepEquals, exptdDst.Inventory.BoltDB)

--- a/management/src/clusterm/manager/set_config_event.go
+++ b/management/src/clusterm/manager/set_config_event.go
@@ -50,8 +50,7 @@ func (e *setConfigEvent) process() error {
 	}()
 
 	// merge the config with default and validate
-	finalConfig := DefaultConfig()
-	err = finalConfig.Merge(e.config)
+	finalConfig, err := DefaultConfig().MergeFromConfig(e.config)
 	if err != nil {
 		return err
 	}

--- a/management/src/clusterm/manager/signal.go
+++ b/management/src/clusterm/manager/signal.go
@@ -1,0 +1,55 @@
+package manager
+
+import (
+	"bufio"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/contiv/errored"
+)
+
+func (m *Manager) reparseConfig() (*Config, error) {
+	f, err := os.Open(m.configFile)
+	if err != nil {
+		return nil, errored.Errorf("failed to open config file. Error: %v", err)
+	}
+	defer func() { f.Close() }()
+	log.Debugf("re-reading configuration from file: %q", m.configFile)
+	reader := bufio.NewReader(f)
+	config := DefaultConfig()
+	uConfig := &Config{}
+	if err := uConfig.Read(reader); err != nil {
+		return nil, errored.Errorf("failed to read configuration. Error: %v", err)
+	}
+	if err := config.Merge(uConfig); err != nil {
+		return nil, errored.Errorf("failed to merge configuration. Error: %v", err)
+	}
+	return config, nil
+}
+
+func (m *Manager) signalLoop() {
+	if strings.TrimSpace(m.configFile) == "" {
+		log.Infof("clusterm started without a config file, not registering signal handler")
+		return
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGHUP)
+
+	for {
+		select {
+		case <-c:
+			config, err := m.reparseConfig()
+			if err != nil {
+				log.Errorf("failed to reparse config. Error: %v", err)
+				continue
+			}
+			if err := NewClient(m.addr).PostConfig(config); err != nil {
+				log.Errorf("error posting config. Error: %v", err)
+			}
+		}
+	}
+}

--- a/management/src/clusterm/manager/signal.go
+++ b/management/src/clusterm/manager/signal.go
@@ -19,12 +19,8 @@ func (m *Manager) reparseConfig() (*Config, error) {
 	defer func() { f.Close() }()
 	log.Debugf("re-reading configuration from file: %q", m.configFile)
 	reader := bufio.NewReader(f)
-	config := DefaultConfig()
-	uConfig := &Config{}
-	if err := uConfig.Read(reader); err != nil {
-		return nil, errored.Errorf("failed to read configuration. Error: %v", err)
-	}
-	if err := config.Merge(uConfig); err != nil {
+	config, err := DefaultConfig().MergeFromReader(reader)
+	if err != nil {
 		return nil, errored.Errorf("failed to merge configuration. Error: %v", err)
 	}
 	return config, nil


### PR DESCRIPTION
This is final part of addressing #176 

- add a handler for SIGHUP signal to update the clusterm configuration by reparsing the configuration file that clusterm was started with
- refactored `Config` methods to simplify code

fixes #176 
