### PR TITLE
Add log streaming API for provisioning jobs and some other fixes

### DIFF
--- a/management/src/clusterctl/commands.go
+++ b/management/src/clusterctl/commands.go
@@ -31,6 +31,14 @@ var (
 		jsonFlag,
 	}
 
+	getJobFlags = []cli.Flag{
+		jsonFlag,
+		cli.BoolFlag{
+			Name:  "follow, f",
+			Usage: "stream job logs (just like tail -f). Only applicable for an active job",
+		},
+	}
+
 	postFlags = []cli.Flag{
 		extraVarsFlag,
 	}
@@ -146,7 +154,7 @@ var (
 					Aliases: []string{"g"},
 					Usage:   "get job info. Expects an arg with value 'active' or 'last'",
 					Action:  doAction(newGetActioner(jobGet)),
-					Flags:   getFlags,
+					Flags:   getJobFlags,
 				},
 			},
 		},
@@ -192,6 +200,7 @@ type parsedFlags struct {
 	extraVars  string
 	hostGroup  string
 	jsonOutput bool
+	streamLogs bool
 }
 
 type actioner interface {

--- a/management/src/clusterm/manager/api_test.go
+++ b/management/src/clusterm/manager/api_test.go
@@ -78,6 +78,25 @@ func (s *apiSuite) TestGetHandlerErrorCase(c *C) {
 			},
 			exptdErr: errJobNotExist("active"),
 		},
+		"logs-invalid-label": {
+			cb: m.jobGet,
+			arg: &APIRequest{
+				Job: "foo",
+			},
+			exptdErr: errInvalidJobLabel("foo"),
+		},
+		"logs-empty-label": {
+			cb:       m.jobGet,
+			arg:      &APIRequest{},
+			exptdErr: errInvalidJobLabel(""),
+		},
+		"logs-non-existent": {
+			cb: m.jobGet,
+			arg: &APIRequest{
+				Job: "active",
+			},
+			exptdErr: errJobNotExist("active"),
+		},
 	}
 
 	for key, test := range tests {

--- a/management/src/clusterm/manager/client.go
+++ b/management/src/clusterm/manager/client.go
@@ -32,26 +32,16 @@ func (c *Client) formURL(rsrc string) string {
 
 func (c *Client) doPost(rsrc string, req *APIRequest) error {
 
-	var reqJSON *bytes.Buffer
-	if req != nil {
-		reqJSON = new(bytes.Buffer)
-		if err := json.NewEncoder(reqJSON).Encode(req); err != nil {
-			return err
-		}
+	var reqJSON bytes.Buffer
+	if err := json.NewEncoder(&reqJSON).Encode(req); err != nil {
+		return err
 	}
 
-	// XXX: http.NewRequest (that http.Post()) calls panics when a reqJSON
-	// variable is nil, hence doing this explicit check here.
-	// golang issue: https://github.com/golang/go/issues/15455
 	var (
 		resp *http.Response
 		err  error
 	)
-	if reqJSON == nil {
-		resp, err = c.httpC.Post(c.formURL(rsrc), "application/json", nil)
-	} else {
-		resp, err = c.httpC.Post(c.formURL(rsrc), "application/json", reqJSON)
-	}
+	resp, err = c.httpC.Post(c.formURL(rsrc), "application/json", &reqJSON)
 	defer resp.Body.Close()
 	if err != nil {
 		return err

--- a/management/src/clusterm/manager/client_test.go
+++ b/management/src/clusterm/manager/client_test.go
@@ -408,7 +408,7 @@ func (s *managerSuite) TestGetNodesSuccess(c *C) {
 		httpC: httpC,
 	}
 
-	resp, err := clstrC.GetNode(testNodeName)
+	resp, err := clstrC.GetAllNodes()
 	c.Assert(err, IsNil)
 	c.Assert(resp, DeepEquals, testGetData)
 }
@@ -459,6 +459,24 @@ func (s *managerSuite) TestGetJobSuccess(c *C) {
 	resp, err := clstrC.GetJob(testJobLabel)
 	c.Assert(err, IsNil)
 	c.Assert(resp, DeepEquals, testGetData)
+}
+
+func (s *managerSuite) TestStreamLogsSuccess(c *C) {
+	expURLStr := fmt.Sprintf("http://%s/%s/%s", baseURL, GetJobLogPrefix, testJobLabel)
+	expURL, err := url.Parse(expURLStr)
+	c.Assert(err, IsNil)
+	httpS, httpC := getHTTPTestClientAndServer(c, okGetReturner(c, expURL))
+	defer httpS.Close()
+	clstrC := Client{
+		url:   baseURL,
+		httpC: httpC,
+	}
+
+	resp, err := clstrC.StreamLogs(testJobLabel)
+	c.Assert(err, IsNil)
+	body, err := ioutil.ReadAll(resp)
+	c.Assert(err, IsNil)
+	c.Assert(body, DeepEquals, testGetData)
 }
 
 func (s *managerSuite) TestGetError(c *C) {

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -46,6 +46,12 @@ const (
 	GetJobPrefix = "info/job"
 	getJob       = GetJobPrefix + "/{job}"
 
+	// GetJobLogPrefix is the prefix for the GET REST endpoint
+	// to stream the logs of a provisioning job. {job} value can be
+	// 'active'
+	GetJobLogPrefix = "info/logs"
+	getJobLog       = GetJobLogPrefix + "/{job}"
+
 	// GetPostConfig is the prefix for the REST endpoint
 	// to GET current or POST updated clusterm's configuration
 	GetPostConfig = "config"

--- a/management/src/clusterm/manager/events.go
+++ b/management/src/clusterm/manager/events.go
@@ -11,10 +11,9 @@ type event interface {
 func (m *Manager) eventLoop() {
 	for {
 		me := <-m.reqQ
-		logrus.Debugf("dequeued manager event: %+v", me)
-		if err := me.process(); err != nil {
-			// log and continue
-			logrus.Errorf("error handling event %q. Error: %s", me, err)
-		}
+		logrus.Debugf("dequeued manager event: %s", me)
+		err := me.process()
+		// log and continue
+		logrus.Debugf("done handling event %s. Error(if any): %v", me, err)
 	}
 }

--- a/management/src/clusterm/manager/multiwriter.go
+++ b/management/src/clusterm/manager/multiwriter.go
@@ -1,0 +1,44 @@
+package manager
+
+import (
+	"io"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// MultiWriter allows writing to multiple writers. It is different from
+// io.MultiWriter() in that it allows adding writers on the fly. The writers
+// added later will only see data from the point of addition.
+type MultiWriter struct {
+	once    sync.Once
+	writers map[io.Writer]struct{}
+}
+
+// Write writes to all the underlying writers. If write to a writer fails
+// then it is evicted from the map
+func (mw *MultiWriter) Write(p []byte) (int, error) {
+	for w := range mw.writers {
+		if _, err := w.Write(p); err != nil {
+			logrus.Debugf("failed to write to writer %+v", w)
+			delete(mw.writers, w)
+		}
+	}
+	return len(p), nil
+}
+
+// Close closes the underlying writers if they implement WriteCloser
+func (mw *MultiWriter) Close() error {
+	for w := range mw.writers {
+		if wc, ok := w.(io.WriteCloser); ok {
+			wc.Close()
+		}
+	}
+	return nil
+}
+
+// Add adds a writer to the list of writers
+func (mw *MultiWriter) Add(w io.Writer) {
+	mw.once.Do(func() { mw.writers = make(map[io.Writer]struct{}) })
+	mw.writers[w] = struct{}{}
+}

--- a/management/src/clusterm/manager/multiwriter_test.go
+++ b/management/src/clusterm/manager/multiwriter_test.go
@@ -1,0 +1,28 @@
+// +build unittest
+
+package manager
+
+import (
+	"bytes"
+
+	. "gopkg.in/check.v1"
+)
+
+type MultiWriterSuite struct {
+}
+
+var _ = Suite(&MultiWriterSuite{})
+
+func (s *MultiWriterSuite) TestMultiWrite(c *C) {
+	mw := &MultiWriter{}
+
+	var buf1, buf2 bytes.Buffer
+	mw.Add(&buf1)
+	mw.Add(&buf2)
+	c.Assert(len(mw.writers), Equals, 2)
+
+	testStr := "foo bar"
+	_, _ = mw.Write([]byte(testStr))
+	c.Assert(buf1.String(), Equals, testStr)
+	c.Assert(buf1.Bytes(), DeepEquals, buf2.Bytes())
+}

--- a/management/src/inventory/boltdb/subsys.go
+++ b/management/src/inventory/boltdb/subsys.go
@@ -1,6 +1,7 @@
 package boltdb
 
 import (
+	"github.com/Sirupsen/logrus"
 	"github.com/contiv/cluster/management/src/boltdb"
 	"github.com/contiv/cluster/management/src/inventory"
 )
@@ -22,7 +23,10 @@ func NewBoltdbSubsys(config boltdb.Config) (*inventory.GeneralSubsys, error) {
 	for _, asset := range assets1 {
 		a := inventory.NewAssetWithState(client, asset.Name, inventory.AssetStatusVals[asset.Status],
 			inventory.AssetStateVals[asset.State])
-		subsys.RestoreAsset(asset.Name, a)
+		if err := subsys.RestoreAsset(asset.Name, a); err != nil {
+			logrus.Infof("failed to restore asset %q. Error: %v", asset.Name, err)
+			continue
+		}
 	}
 
 	return subsys, nil

--- a/management/src/inventory/collins/subsys.go
+++ b/management/src/inventory/collins/subsys.go
@@ -1,6 +1,7 @@
 package collins
 
 import (
+	"github.com/Sirupsen/logrus"
 	"github.com/contiv/cluster/management/src/collins"
 	"github.com/contiv/cluster/management/src/inventory"
 	"github.com/contiv/errored"
@@ -27,7 +28,10 @@ func NewCollinsSubsys(config collins.Config) (*inventory.GeneralSubsys, error) {
 	for _, asset := range assets1 {
 		a := inventory.NewAssetWithState(client, asset.Tag, inventory.AssetStatusVals[asset.Status],
 			inventory.AssetStateVals[asset.State.Name])
-		subsys.RestoreAsset(asset.Tag, a)
+		if err := subsys.RestoreAsset(asset.Tag, a); err != nil {
+			logrus.Infof("failed to restore asset %q. Error: %v", asset.Tag, err)
+			continue
+		}
 	}
 
 	return subsys, nil


### PR DESCRIPTION
Summary:
-  Provision for streaming logs of a running job through `job.PipeLogs()` method
    - Added MultiWriter type to all basic broadcast of writes to multiple writers
    - MultiWriter is used to in turn buffer job logs, as well as allow clients to request a stream (just like tail -f)
- API endpoint to stream job logs
    - Added 'info/logs/{job}' endpoint to stream job logs
    - Added StreamLogs method to clusterm client to exercise info/logs endpoint
       - The method returns a io.ReadCloser that the caller shall use to access the log stream of a job
    - Added clusterctl CLI to stream logs of an active job
- improved error handling/reporting in clusterctl get commands
- added missing logs for:
   - asset restore errors
   - unconditionally log event completion status
- cleaned up request writing code in `client.doPost()` method

/cc @vvb @vishal-j 

@vishal-j , this is related to something we discussed a while back for the UI. Basically with this API endpoint the UI can avoid the periodic refresh logic when showing job logs !