### PR TITLE
add net/http/pprof profiling endpoints to clusterm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -174,8 +174,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 #in a test specific conf file (see the test-suite setup function)
                 node.vm.synced_folder ".", "/vagrant"
 
-                # expose collins port to host for ease of management
-                node.vm.network "forwarded_port", guest: 9000, host: 9000
+                # expose clusterm port to host for ease of trying out cluster API
+                node.vm.network "forwarded_port", guest: 9007, host: 9007
 
                 # expose UCP UI to the host on port
                 node.vm.network "forwarded_port", guest: 443, host:9091 

--- a/management/src/clusterm/manager/api.go
+++ b/management/src/clusterm/manager/api.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -86,6 +87,12 @@ func (m *Manager) apiLoop(errCh chan error, servingCh chan struct{}) {
 			{"/" + getJob, emptyHdrs, get(m.jobGet)},
 			{"/" + getJobLog, emptyHdrs, get(m.logsGet)},
 			{"/" + GetPostConfig, emptyHdrs, get(m.configGet)},
+			{"/" + getDebugPrefix + "/", emptyHdrs, pprof.Index},
+			{"/" + getDebugPrefix + "/cmdline", emptyHdrs, pprof.Cmdline},
+			{"/" + getDebugPrefix + "/profile", emptyHdrs, pprof.Profile},
+			{"/" + getDebugPrefix + "/symbol", emptyHdrs, pprof.Symbol},
+			{"/" + getDebugPrefix + "/trace", emptyHdrs, pprof.Trace},
+			{"/" + getDebug, emptyHdrs, pprof.Index},
 		},
 		"POST": {
 			{"/" + PostNodesCommission, jsonContentHdrs, post(m.nodesCommission)},

--- a/management/src/clusterm/manager/consts.go
+++ b/management/src/clusterm/manager/consts.go
@@ -55,6 +55,14 @@ const (
 	// GetPostConfig is the prefix for the REST endpoint
 	// to GET current or POST updated clusterm's configuration
 	GetPostConfig = "config"
+
+	// GetDebug is the prefix for the GET REST endpoint
+	// to fetch the debug/profile information for clusterm
+	// as provided by net/http/pprof package
+	// Note: We can't use our custom prefix style here as net/http/pprof
+	// package requires the request prefix to be 'debug/pprof'
+	getDebugPrefix = "debug/pprof"
+	getDebug       = getDebugPrefix + "/{profile}"
 )
 
 const (


### PR DESCRIPTION
This will enable profiling clusterm using pprof and visualizing using go-torch . 

Also removed collins port and added clusterm API port in Vagrantfile

