### PR TITLE
use sync.errgroup package for error propagation

### DIFF
--- a/management/src/Godeps/Godeps.json
+++ b/management/src/Godeps/Godeps.json
@@ -1,10 +1,10 @@
 {
 	"ImportPath": "github.com/contiv/cluster/management/src",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v60",
+	"GodepVersion": "v62",
 	"Packages": [
 		"github.com/contiv/cluster/management/src/ansible",
-		"github.com/contiv/cluster/management/src/boltdb/inventory",
+		"github.com/contiv/cluster/management/src/boltdb",
 		"github.com/contiv/cluster/management/src/clusterctl",
 		"github.com/contiv/cluster/management/src/clusterm",
 		"github.com/contiv/cluster/management/src/clusterm/manager",
@@ -13,7 +13,6 @@
 		"github.com/contiv/cluster/management/src/inventory",
 		"github.com/contiv/cluster/management/src/inventory/boltdb",
 		"github.com/contiv/cluster/management/src/inventory/collins",
-		"github.com/contiv/cluster/management/src/mock",
 		"github.com/contiv/cluster/management/src/monitor",
 		"github.com/contiv/cluster/management/src/systemtests"
 	],
@@ -157,6 +156,10 @@
 		{
 			"ImportPath": "golang.org/x/net/context",
 			"Rev": "76365a41624aa608f888301bf60fabecaf928b5a"
+		},
+		{
+			"ImportPath": "golang.org/x/sync/errgroup",
+			"Rev": "316e794f7b5e3df4e95175a45a5fb8b12f85cb4f"
 		},
 		{
 			"ImportPath": "golang.org/x/sys/unix",

--- a/management/src/clusterm/main.go
+++ b/management/src/clusterm/main.go
@@ -102,10 +102,7 @@ func startDaemon(c *cli.Context) {
 	}
 
 	// start manager's processing loop
-	errCh := make(chan error, 5)
-	go mgr.Run(errCh)
-	select {
-	case err := <-errCh:
+	if err := mgr.Run(); err != nil {
 		logrus.Fatalf("encountered an error: %s", err)
 	}
 }

--- a/management/src/clusterm/manager/api.go
+++ b/management/src/clusterm/manager/api.go
@@ -70,7 +70,7 @@ func errNilConfig() error {
 	return errored.Errorf("nil value specified for clusterm configuration")
 }
 
-func (m *Manager) apiLoop(errCh chan error, servingCh chan struct{}) {
+func (m *Manager) apiLoop(servingCh chan struct{}) error {
 	//set following headers for requests expecting a body
 	jsonContentHdrs := []string{"Content-Type", "application/json"}
 	//set following headers for requests that don't expect a body like get node info.
@@ -115,8 +115,7 @@ func (m *Manager) apiLoop(errCh chan error, servingCh chan struct{}) {
 	l, err := net.Listen("tcp", m.addr)
 	if err != nil {
 		logrus.Errorf("Error setting up listener. Error: %s", err)
-		errCh <- err
-		return
+		return err
 	}
 
 	//signal that socket is being served
@@ -124,9 +123,10 @@ func (m *Manager) apiLoop(errCh chan error, servingCh chan struct{}) {
 
 	if err := http.Serve(l, r); err != nil {
 		logrus.Errorf("Error listening for http requests. Error: %s", err)
-		errCh <- err
-		return
+		return err
 	}
+
+	return nil
 }
 
 type postCallback func(req *APIRequest) error

--- a/management/src/clusterm/manager/monitor.go
+++ b/management/src/clusterm/manager/monitor.go
@@ -33,9 +33,10 @@ func (m *Manager) enqueueMonitorEvent(events []monitor.Event) {
 	}
 }
 
-func (m *Manager) monitorLoop(errCh chan error) {
+func (m *Manager) monitorLoop() error {
 	if err := m.monitor.Start(); err != nil {
 		logrus.Errorf("monitoring subsystem encountered a failure. Error: %s", err)
-		errCh <- err
+		return err
 	}
+	return nil
 }

--- a/management/src/vendor/golang.org/x/sync/LICENSE
+++ b/management/src/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/management/src/vendor/golang.org/x/sync/PATENTS
+++ b/management/src/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/management/src/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/management/src/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}


### PR DESCRIPTION
this simplifies the logic a bit by getting rid of the need to pass a special channel for signalling errors
